### PR TITLE
Update sequencer to have the option to reference finalized l1 blocks instead of the current head of the L1

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -36,6 +36,17 @@ func init() {
 	cli.VersionFlag.(*cli.BoolFlag).Category = MiscCategory
 }
 
+func init() {
+	DeprecatedFlags = append(DeprecatedFlags, deprecatedP2PFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, P2PFlags(EnvVarPrefix)...)
+	optionalFlags = append(optionalFlags, oplog.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
+	optionalFlags = append(optionalFlags, oppprof.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
+	optionalFlags = append(optionalFlags, DeprecatedFlags...)
+	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, RollupCategory)...)
+	optionalFlags = append(optionalFlags, altda.CLIFlags(EnvVarPrefix, AltDACategory)...)
+	Flags = append(requiredFlags, optionalFlags...)
+}
+
 func prefixEnvVars(names ...string) []string {
 	envs := make([]string, 0, len(names))
 	for _, name := range names {
@@ -249,6 +260,13 @@ var (
 		Value:    4,
 		Category: SequencerCategory,
 	}
+	SequencerUseFinalizedL1Flag = &cli.BoolFlag{
+		Name:     "sequencer.use-finalized",
+		Usage:    "Enable use of only finalized L1 blocks as L1 origin. Overwrites the value of 'sequencer.l1-confs'.",
+		EnvVars:  prefixEnvVars("SEQUENCER_USE_FINALIZED"),
+		Value:    false,
+		Category: SequencerCategory,
+	}
 	L1EpochPollIntervalFlag = &cli.DurationFlag{
 		Name:     "l1.epoch-poll-interval",
 		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
@@ -443,6 +461,7 @@ var optionalFlags = []cli.Flag{
 	L1RPCMaxConcurrency,
 	L1HTTPPollInterval,
 	L1CacheSize,
+	SequencerUseFinalizedL1Flag,
 	VerifierL1Confs,
 	SequencerEnabledFlag,
 	SequencerStoppedFlag,
@@ -484,17 +503,6 @@ var DeprecatedFlags = []cli.Flag{
 
 // Flags contains the list of configuration options available to the binary.
 var Flags []cli.Flag
-
-func init() {
-	DeprecatedFlags = append(DeprecatedFlags, deprecatedP2PFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, P2PFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, oplog.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
-	optionalFlags = append(optionalFlags, oppprof.CLIFlagsWithCategory(EnvVarPrefix, OperationsCategory)...)
-	optionalFlags = append(optionalFlags, DeprecatedFlags...)
-	optionalFlags = append(optionalFlags, opflags.CLIFlags(EnvVarPrefix, RollupCategory)...)
-	optionalFlags = append(optionalFlags, altda.CLIFlags(EnvVarPrefix, AltDACategory)...)
-	Flags = append(requiredFlags, optionalFlags...)
-}
 
 func CheckRequired(ctx *cli.Context) error {
 	for _, f := range requiredFlags {

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,8 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// SequencerUseFinalized is true when sequencer should use only finalized L1 blocks as origin.
+	// If this is set to true, the value of `SequencerConfDepth` is ignored.
+	SequencerUseFinalized bool `json:"sequencer_use_finalized"`
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/finality"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/finalized"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/status"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -237,8 +238,13 @@ func NewDriver(
 	if driverCfg.SequencerEnabled {
 		asyncGossiper := async.NewAsyncGossiper(driverCtx, network, log, metrics)
 		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
-		sequencerConfDepth := confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
-		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, sequencerConfDepth)
+		var seqL1Blocks sequencing.L1Blocks
+		if driverCfg.SequencerUseFinalized {
+			seqL1Blocks = finalized.NewFinalized(statusTracker.L1Finalized, l1)
+		} else {
+			seqL1Blocks = confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
+		}
+		findL1Origin := sequencing.NewL1OriginSelector(driverCtx, log, cfg, seqL1Blocks)
 		sys.Register("origin-selector", findL1Origin, opts)
 		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)

--- a/op-node/rollup/finalized/finalized.go
+++ b/op-node/rollup/finalized/finalized.go
@@ -1,0 +1,29 @@
+package finalized
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type finalized struct {
+	derive.L1Fetcher
+	l1Finalized func() eth.L1BlockRef
+}
+
+func NewFinalized(l1Finalized func() eth.L1BlockRef, fetcher derive.L1Fetcher) *finalized {
+	return &finalized{L1Fetcher: fetcher, l1Finalized: l1Finalized}
+}
+
+func (f *finalized) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
+	l1Finalized := f.l1Finalized()
+	if num == 0 || num <= l1Finalized.Number {
+		return f.L1Fetcher.L1BlockRefByNumber(ctx, num)
+	}
+	return eth.L1BlockRef{}, ethereum.NotFound
+}
+
+var _ derive.L1Fetcher = (*finalized)(nil)

--- a/op-node/rollup/finalized/finalized_test.go
+++ b/op-node/rollup/finalized/finalized_test.go
@@ -1,0 +1,58 @@
+package finalized
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+var testFinalHash = common.Hash{0x01}
+
+type finalizedTest struct {
+	name  string
+	final uint64
+	hash  common.Hash // hash of finalized block
+	req   uint64
+	pass  bool
+}
+
+func (ft *finalizedTest) Run(t *testing.T) {
+	l1Fetcher := &testutils.MockL1Source{}
+	l1Finalized := eth.L1BlockRef{Number: ft.final, Hash: ft.hash}
+	l1FinalizedGetter := func() eth.L1BlockRef { return l1Finalized }
+
+	f := NewFinalized(l1FinalizedGetter, l1Fetcher)
+
+	if ft.pass {
+		// no calls to the l1Fetcher are made if the block number is not finalized yet
+		l1Fetcher.ExpectL1BlockRefByNumber(ft.req, eth.L1BlockRef{Number: ft.req}, nil)
+	}
+
+	out, err := f.L1BlockRefByNumber(context.Background(), ft.req)
+	l1Fetcher.AssertExpectations(t)
+
+	if ft.pass {
+		require.NoError(t, err)
+		require.Equal(t, out, eth.L1BlockRef{Number: ft.req})
+	} else {
+		require.Equal(t, ethereum.NotFound, err)
+	}
+}
+
+func TestFinalized(t *testing.T) {
+	testCases := []finalizedTest{
+		{name: "finalized", final: 10, hash: testFinalHash, req: 10, pass: true},
+		{name: "finalized past", final: 10, hash: testFinalHash, req: 8, pass: true},
+		{name: "not finalized", final: 10, hash: testFinalHash, req: 11, pass: false},
+		{name: "no L1 state", req: 10, pass: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.Run)
+	}
+}

--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -145,3 +145,8 @@ func (st *StatusTracker) SyncStatus() *eth.SyncStatus {
 func (st *StatusTracker) L1Head() eth.L1BlockRef {
 	return st.SyncStatus().HeadL1
 }
+
+// L1Finalized is a helper function to get the latest known finalized L1 block.
+func (st *StatusTracker) L1Finalized() eth.L1BlockRef {
+	return st.SyncStatus().FinalizedL1
+}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -189,11 +189,12 @@ func NewConfigPersistence(ctx *cli.Context) node.ConfigPersistence {
 
 func NewDriverConfig(ctx *cli.Context) *driver.Config {
 	return &driver.Config{
-		VerifierConfDepth:   ctx.Uint64(flags.VerifierL1Confs.Name),
-		SequencerConfDepth:  ctx.Uint64(flags.SequencerL1Confs.Name),
-		SequencerEnabled:    ctx.Bool(flags.SequencerEnabledFlag.Name),
-		SequencerStopped:    ctx.Bool(flags.SequencerStoppedFlag.Name),
-		SequencerMaxSafeLag: ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		VerifierConfDepth:     ctx.Uint64(flags.VerifierL1Confs.Name),
+		SequencerConfDepth:    ctx.Uint64(flags.SequencerL1Confs.Name),
+		SequencerEnabled:      ctx.Bool(flags.SequencerEnabledFlag.Name),
+		SequencerStopped:      ctx.Bool(flags.SequencerStoppedFlag.Name),
+		SequencerMaxSafeLag:   ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		SequencerUseFinalized: ctx.Bool(flags.SequencerUseFinalizedL1Flag.Name),
 	}
 }
 


### PR DESCRIPTION
Closes #50 
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Ports the change provided by Celo to target their finalized blocks.
Repo: https://github.com/celo-org/optimism
commit: [661aa0c49238167630012827f4e207f9732f0300](https://github.com/celo-org/optimism/commit/661aa0c49238167630012827f4e207f9732f0300)

This change adds the flag `sequencer.use-finalized` that makes the Rollup Driver consider the `L1Finalized` block reference instead of the `L1Head` as the `L1Origin` when building blocks.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
Add any other changes from the Celo repo.

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

### How to test this PR:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->
A new test has been added to test the behavior of the the implementation of the `NewFinalized` implementation of a `L1Fetcher`.  It is located at op-node/rollup/finalized/finalized_test.go.

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209392461754540