### PR TITLE
Tests infrastructure improvements

### DIFF
--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -107,6 +107,11 @@ This step is only needed if you use Mises as Nix automatically installs the Espr
 
 ### Run the tests
 
-To run the tests:
+To run all the tests (slow):
 
 > just tests
+
+
+To run a subset of the tests (fast):
+
+> just fast-tests

--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -46,7 +46,64 @@ Finally, install all the dependencies:
 > mise install
 ```
 
-*
+### Install Espresso go cryptographic library
+
+This step is only needed if you use Mises as Nix automatically installs the Espresso go cryptographic library.
+
+- Create a local directory for later use. Note it has to be created under the home directory by default.
+
+  ```bash
+  cd ..
+  mkdir -p ~/local-lib
+  ```
+
+- Get `libespresso_crypto_helper.a`, by either method below.
+  - Get it from the CI. See https://github.com/EspressoSystems/espresso-network-go/releases
+    - Download `libespresso_crypto_helper-x86_64-apple-darwin.a` (or the one for linux).
+    - Move the downloaded file to `local-lib`.
+
+  - Build it locally.
+    - Download the sequencer Go code via `https://github.com/EspressoSystems/espresso-network-go/archive/refs/tags/v0.0.34.tar.gz`.
+      - Replace the version number if there’s a newer one.
+    - Go to the downloaded folder.
+
+      ```bash
+      cd espresso-network-go-0.0.34
+      ```
+
+    - Build the verification code.
+      - Make sure to not run this in the nix shell. Otherwise, the generated file will be in the wrong directory, which will cause `just` to fail later.
+      - This may require `rustup update` if the Rust version is older than expected.
+
+      ```bash
+      cargo build --release --locked --manifest-path ./verification/rust/Cargo.toml
+      ```
+
+    - Copy the `libespresso_crypto_helper.a` file.
+      - Linux:
+
+        ```bash
+        sudo cp ./espresso-network-go-0.0.34/verification/rust/target/release/libespresso_crypto_helper.a ~/local-lib/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a
+        ```
+
+      - Mac:
+
+        ```bash
+        sudo cp ./espresso-network-go-0.0.34/verification/rust/target/release/libespresso_crypto_helper.a ~/local-lib/libespresso_crypto_helper-x86_64-apple-darwin.a
+        ```
+
+- Set the flag.
+  - Linux:
+
+      ```bash
+      export CGO_LDFLAGS="-L$HOME/local-lib -lespresso_crypto_helper-x86_64-unknown-linux-gnu"
+      ```
+
+  - Mac:
+
+      ```bash
+      export CGO_LDFLAGS="-L$HOME/local-lib -lespresso_crypto_helper-x86_64-apple-darwin -framework Foundation -framework SystemConfiguration"
+      ```
 
 ### Run the tests
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,10 @@
         inputs.foundry.overlay
       ];
       pkgs = import inputs.nixpkgs { inherit overlays system;};
+      downloadedFile = pkgs.fetchurl {
+              url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a";
+              sha256 = "sha256:1c7ybrqjrp1709j08fk7zcr5q8hyfakvgv0m64zn2fywlqfdpszs";
+            };
       in
       {
         devShell = pkgs.mkShell {
@@ -27,6 +31,12 @@
             pkgs.go_1_22
             pkgs.gotools
           ];
+          shellHook = ''
+                    export DOWNLOADED_FILE_PATH=${downloadedFile}
+                    echo "Downloaded file is at $DOWNLOADED_FILE_PATH"
+                    ln -sf /nix/store/8b5ranvnlb7sjrzpdpbb75vdp0gsyb1x-libespresso_crypto_helper-x86_64-unknown-linux-gnu.a /tmp/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a
+                    export CGO_LDFLAGS="-L/tmp -lespresso_crypto_helper-x86_64-unknown-linux-gnu"
+                  '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -18,19 +18,27 @@
                   url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a";
                   sha256 = "sha256:1c7ybrqjrp1709j08fk7zcr5q8hyfakvgv0m64zn2fywlqfdpszs";
                 }
-                else
+                else if system == "x86_64-darwin" then
                   pkgs.fetchurl {
                     url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-apple-darwin.a";
                     sha256 = "sha256:1fbijfam49c2i2l0d56i0zgczcbh2gljc6fh63g7qq3h7b7z5wc6";
-                  };
+                  }
+                else # aarch64-darwin
+                  pkgs.fetchurl {
+                        url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-aarch64-apple-darwin.a";
+                        sha256 = "sha256:18iqpqm3jmvj20vdd8zz05891lw5sxqy6vhfc8ghmg55czabip2q";
+                  }
+                  ;
       cgo_ld_flags = if system == "x86_64-linux"
                       then "-L/tmp -lespresso_crypto_helper-x86_64-unknown-linux-gnu"
-                      else "-L/tmp -lespresso_crypto_helper-x86_64-apple-darwin -framework Foundation -framework SystemConfiguration"
+                      else if system == "x86_64-darwin" then "-L/tmp -lespresso_crypto_helper-x86_64-apple-darwin -framework Foundation -framework SystemConfiguration"
+                      else "-L/tmp -lespresso_crypto_helper-aarch64-apple-darwin -framework Foundation -framework SystemConfiguration" # aarch64-darwin
       ;
 
-      target_link =  if system == "x86_64-linux"
-                      then "/tmp/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a"
-                      else "/tmp/libespresso_crypto_helper-x86_64-apple-darwin.a";
+      target_link =  if system == "x86_64-linux" then  "/tmp/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a"
+                      else if system == "x86_64-darwin" then "/tmp/libespresso_crypto_helper-x86_64-apple-darwin.a"
+                      else "/tmp/libespresso_crypto_helper-aarch64-apple-darwin.a" # aarch64-darwin
+                      ;
 
       in
       {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         inputs.foundry.overlay
       ];
       pkgs = import inputs.nixpkgs { inherit overlays system;};
-      espressoGoLibFile =  if system == "x86_64-linux"
+      espressoGoLibFile = if system == "x86_64-linux"
                 then pkgs.fetchurl {
                   url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a";
                   sha256 = "sha256:1c7ybrqjrp1709j08fk7zcr5q8hyfakvgv0m64zn2fywlqfdpszs";

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
                   };
       cgo_ld_flags = if system == "x86_64-linux"
                       then "-L/tmp -lespresso_crypto_helper-x86_64-unknown-linux-gnu"
-                      else "-L/tmp -lespresso_crypto_helper-x86_64-apple-darwin.a -framework Foundation -framework SystemConfiguration"
+                      else "-L/tmp -lespresso_crypto_helper-x86_64-apple-darwin -framework Foundation -framework SystemConfiguration"
       ;
 
       target_link =  if system == "x86_64-linux"

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,25 @@
         inputs.foundry.overlay
       ];
       pkgs = import inputs.nixpkgs { inherit overlays system;};
-      downloadedFile = pkgs.fetchurl {
-              url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a";
-              sha256 = "sha256:1c7ybrqjrp1709j08fk7zcr5q8hyfakvgv0m64zn2fywlqfdpszs";
-            };
+      espressoGoLibFile =  if system == "x86_64-linux"
+                then pkgs.fetchurl {
+                  url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a";
+                  sha256 = "sha256:1c7ybrqjrp1709j08fk7zcr5q8hyfakvgv0m64zn2fywlqfdpszs";
+                }
+                else
+                  pkgs.fetchurl {
+                    url = "https://github.com/EspressoSystems/espresso-network-go/releases/download/v0.0.34/libespresso_crypto_helper-x86_64-apple-darwin.a";
+                    sha256 = "sha256:1fbijfam49c2i2l0d56i0zgczcbh2gljc6fh63g7qq3h7b7z5wc6";
+                  };
+      cgo_ld_flags = if system == "x86_64-linux"
+                      then "-L/tmp -lespresso_crypto_helper-x86_64-unknown-linux-gnu"
+                      else "-L/tmp -lespresso_crypto_helper-x86_64-apple-darwin.a -framework Foundation -framework SystemConfiguration"
+      ;
+
+      target_link =  if system == "x86_64-linux"
+                      then "/tmp/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a"
+                      else "/tmp/libespresso_crypto_helper-x86_64-apple-darwin.a";
+
       in
       {
         devShell = pkgs.mkShell {
@@ -32,10 +47,10 @@
             pkgs.gotools
           ];
           shellHook = ''
-                    export DOWNLOADED_FILE_PATH=${downloadedFile}
-                    echo "Downloaded file is at $DOWNLOADED_FILE_PATH"
-                    ln -sf /nix/store/8b5ranvnlb7sjrzpdpbb75vdp0gsyb1x-libespresso_crypto_helper-x86_64-unknown-linux-gnu.a /tmp/libespresso_crypto_helper-x86_64-unknown-linux-gnu.a
-                    export CGO_LDFLAGS="-L/tmp -lespresso_crypto_helper-x86_64-unknown-linux-gnu"
+                    export DOWNLOADED_FILE_PATH=${espressoGoLibFile}
+                    echo "Espresso go library stored at $DOWNLOADED_FILE_PATH"
+                    ln -sf ${espressoGoLibFile} ${target_link}
+                    export CGO_LDFLAGS="${cgo_ld_flags}"
                   '';
         };
       }

--- a/justfile
+++ b/justfile
@@ -2,6 +2,9 @@
 tests:
  ./run_all_tests.sh
 
+fast-tests:
+ ./run_fast_tests.sh
+
 # Clean up everything before running the tests
 nuke:
  make nuke

--- a/run_fast_tests.sh
+++ b/run_fast_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Configure the shell to trigger the exit trap on any non successful error code
+set -eu
+
+# Configure a trap handler to run at the end of any unsuccessful script.  This
+# will allow us to exist immediately following the failed test, so that it can
+# be inspected / debugged.
+trap "exit" INT TERM
+trap end EXIT
+end(){
+    if [[ $? -ne 0 ]]; then
+        echo "Tests failed :("
+        echo "Figure out why"
+        exit 1
+    fi
+}
+
+# We run nuke before we run the tests, in order to make sure we're starting
+# from a clean slate.
+make nuke
+
+# Some of the following tests depend on the existence of the forge-artifacts
+# folder under `packages/contracts-bedrock`.  This folder is created by running
+# the cannon tests, so we need to ensure that it is run first.
+# make -C ./cannon test
+(cd packages/contracts-bedrock && just build-dev)
+
+just -f ./op-batcher/justfile test
+just -f ./op-node/justfile test
+
+# Just to be nice we run nuke again, so we don't have any residual state
+# left around.
+make nuke
+
+echo Ok!


### PR DESCRIPTION
Closes https://app.asana.com/0/1209392461754458/1209825596794240/f

### This PR:

* Improves the nix expression in order to automatically download and install the Espresso go cryptographic library.
* Add a script to run fast tests (only the tests for the batcher and the op-node)
* Updates `ESPRESSO_README.md`.


### Key places to review:

* `flake.nix`
* `ESPRESSO_README.md`
* `run_fast_tests.sh`

<!-- ### How to test this PR:  -->

The new nix expression has been tested under linux only but should work with Mac OS. To test do:
```
> nix develop .
> just tests
```

**Note that it is not necessary anymore to download the binaries from https://github.com/EspressoSystems/espresso-network-go/releases and set the `CGO_LDFLAG` environment variables**.

To run the fast tests:
```
> just fast-tests
```


