### PR TITLE
Fix Kurtosis devnet error

### DIFF
--- a/kurtosis-devnet/espresso.yaml
+++ b/kurtosis-devnet/espresso.yaml
@@ -1,6 +1,4 @@
 optimism_package:
-  observability:
-    enabled: false
   altda_deploy_config:
     use_altda: false
   chains:

--- a/op-node/rollup/derive/espresso_streamer.go
+++ b/op-node/rollup/derive/espresso_streamer.go
@@ -152,23 +152,27 @@ batchLoop:
 		s.log.Error("failed to get the L1 finalized block", "err", err)
 		return nil, false, NotEnoughData
 	}
-	if returnBatch.Epoch().Number > l1FinalizedBlock.Number {
-		// we will not change s.messagesWithHeights here, because we want to keep the same lists of batches
-		s.log.Warn("you need to wait longer for the L1 origin to be finalized", "l1_origin", returnBatch.Epoch().Number)
-		return nil, false, NotEnoughData
-	} else {
-		// make sure it's a valid L1 origin state by check the hash
-		expectedL1BlockRef, err := l1BlockRefByNumber(ctx, returnBatch.Epoch().Number)
-		if err != nil {
-			s.log.Warn("failed to get the L1 block ref by number", "err", err, "l1_origin_number", returnBatch.Epoch().Number)
-			return nil, false, err
-		}
-		if returnBatch.Epoch().Hash != expectedL1BlockRef.Hash {
-			s.log.Warn("the L1 origin hash is not valid anymore", "l1_origin", returnBatch.Epoch().Hash, "expected", expectedL1BlockRef.Hash)
-			// drop the batch and wait longer
-			s.messagesWithHeights = remaining
+	if returnBatch != nil {
+		if returnBatch.Epoch().Number > l1FinalizedBlock.Number {
+			// we will not change s.messagesWithHeights here, because we want to keep the same lists of batches
+			s.log.Warn("you need to wait longer for the L1 origin to be finalized", "l1_origin", returnBatch.Epoch().Number)
 			return nil, false, NotEnoughData
+		} else {
+			// make sure it's a valid L1 origin state by check the hash
+			expectedL1BlockRef, err := l1BlockRefByNumber(ctx, returnBatch.Epoch().Number)
+			if err != nil {
+				s.log.Warn("failed to get the L1 block ref by number", "err", err, "l1_origin_number", returnBatch.Epoch().Number)
+				return nil, false, err
+			}
+			if returnBatch.Epoch().Hash != expectedL1BlockRef.Hash {
+				s.log.Warn("the L1 origin hash is not valid anymore", "l1_origin", returnBatch.Epoch().Hash, "expected", expectedL1BlockRef.Hash)
+				// drop the batch and wait longer
+				s.messagesWithHeights = remaining
+				return nil, false, NotEnoughData
+			}
 		}
+	} else {
+		s.log.Warn("No next batch")
 	}
 
 	s.messagesWithHeights = remaining

--- a/op-node/rollup/derive/espresso_streamer.go
+++ b/op-node/rollup/derive/espresso_streamer.go
@@ -173,6 +173,7 @@ batchLoop:
 		}
 	} else {
 		s.log.Warn("No next batch")
+		return nil, false, NotEnoughData
 	}
 
 	s.messagesWithHeights = remaining


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1209899580464292?focus=true.

### This PR:
* Removes the duplicate `observability` flag.
* Adds `nil` check for `SingularBatch` before calling `Epoch()`.

### Key places to review:
* The removal of the `observability` tag.
* The new `if returnBatch != nil` condition.

### How to test this PR:
* Run `espresso-devnet`.

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
