### PR TITLE
Document fix for tool version mismatch

### DIFF
--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -122,8 +122,6 @@ Run the Espresso integration tests:
 > just espresso-tests
 
 
-If any `just` command fails with a tool version mismatch error such as
-`version "go1.22.7" does not match go tool version "go1.22.12"`, use `which go` to get the expected
-Go version, which looks like `h3152254ziz6ag01wnccj0dlp8990w1q-go-1.22.12`, then set the version
-using `export GOROOT='/nix/store/{version}/share/go'` with `version` replaced with the fetched
-version.
+If in the Nix environment, any `just` command fails with a tool version mismatch error such as
+`version "go1.22.7" does not match go tool version "go1.22.12"`, use
+`export GOROOT="$(dirname $(dirname $(which go)))/share/go"` to set the expected Go version.

--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -120,3 +120,10 @@ To run a subset of the tests (fast):
 Run the Espresso integration tests:
 
 > just espresso-tests
+
+
+If any `just` command fails with a tool version mismatch error such as
+`version "go1.22.7" does not match go tool version "go1.22.12"`, use `which go` to get the expected
+Go version, which looks like `h3152254ziz6ag01wnccj0dlp8990w1q-go-1.22.12`, then set the version
+using `export GOROOT='/nix/store/{version}/share/go'` with `version` replaced with the fetched
+version.


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1209906194218304?focus=true.

### This PR:
* Document how to fix the Go version mismatch error.
