### PR TITLE
Fix L2 progress & enable derivation from caff node

### DIFF
--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -123,17 +123,16 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 
 			var espressoBatch = aq.espressoStreamer.Next(ctx)
 			if espressoBatch == nil {
-				// batch = nil
-				// concluding = false
-				// err = NotEnoughData
+				batch = nil
+				concluding = true
+				err = NotEnoughData
 			} else {
 				log.Info("espressoBatch", "batch", espressoBatch.Batch)
-				// batch = &espressoBatch.Batch
-				// For caff node, assign concluding to false for now
-				// concluding = false
-				// err = nil
+				batch = &espressoBatch.Batch
+				// For caff node, assign concluding to true for now
+				concluding = true
+				err = nil
 			}
-			batch, concluding, err = aq.prev.NextBatch(ctx, parent)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- Enable next() from espresso streamer so that the derivation pipeline really include caff node mode
- Fix the issue L2 not progressing properly with caff node, however, not sure about the root cause yet
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

### How to test this PR: 
Running kurtosis devnet, and you should be able to see lots of `Record safe head` in the log of `op-el-1-op-node-op-geth-op-kurtosis`.
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
