### PR TITLE
Remaining list  implementation

### DIFF
--- a/espresso/environment/3_1_espresso_caff_node_test.go
+++ b/espresso/environment/3_1_espresso_caff_node_test.go
@@ -37,7 +37,7 @@ func TestE2eDevNetWithEspressoWithCaffNodeDeterministicDerivation(t *testing.T) 
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, 0)
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/5_batch_authentication_test.go
+++ b/espresso/environment/5_batch_authentication_test.go
@@ -28,7 +28,7 @@ func TestE2eDevNetWithInvalidAttestation(t *testing.T) {
 	}
 
 	system, _, err :=
-		launcher.StartDevNet(ctx, t,
+		launcher.StartDevNet(ctx, t, 0,
 			env.SetBatcherKey(*privateKey),
 			env.Config(func(cfg *e2esys.SystemConfig) {
 				cfg.DisableBatcher = true
@@ -71,7 +71,7 @@ func TestE2eDevNetWithUnattestedBatcherKey(t *testing.T) {
 	}
 
 	system, _, err :=
-		launcher.StartDevNet(ctx, t,
+		launcher.StartDevNet(ctx, t, 0,
 			env.SetBatcherKey(*privateKey),
 		)
 	if have, want := err, error(nil); have != want {

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -108,10 +108,11 @@ func TestStatelessBatcher(t *testing.T) {
 
 		// The batcher is up, we can send coins
 		if batcherIsUp {
-			_ = helpers.SendDepositTx(t, system.Cfg, l1Client, l2Verif, bobOptions, func(l2Opts *helpers.DepositTxOpts) {
+			receipt := helpers.SendDepositTx(t, system.Cfg, l1Client, l2Verif, bobOptions, func(l2Opts *helpers.DepositTxOpts) {
 				// Send from Bob to Alice
 				l2Opts.ToAddr = addressAlice
 			})
+			t.Log("Deposit transaction receipt", "receipt", receipt)
 			numDeposits++
 		}
 

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"math/big"
+	"math/rand/v2"
 	"testing"
+	"time"
 )
 
 // TestStatelessBatcher is a test that verifies a batcher can operate (especially restart) correctly and efficiently without persistent storage.
@@ -75,32 +78,31 @@ func TestStatelessBatcher(t *testing.T) {
 
 	var caffBalanceNew *big.Int
 
-	//driver := system.BatchSubmitter.TestDriver()
+	driver := system.BatchSubmitter.TestDriver()
 	numIterations := 10
 
 	// We select a range of iterations when the batcher is turned off.
-	//turnBatcherOffIteration := rand.IntN(numIterations / 2)
-	//turnBatcherOnIteration := rand.IntN(numIterations/2) + numIterations/2
+	turnBatcherOffIteration := rand.IntN(numIterations / 2)
+	turnBatcherOnIteration := rand.IntN(numIterations/2) + numIterations/2
 
 	batcherIsUp := true
 	for i := 0; i < numIterations; i++ {
 
 		t.Log("******************* Iteration: ", i)
 		//Let us stop the batcher
-		//if i == turnBatcherOffIteration {
-		//
-		//	err = driver.StopBatchSubmitting(ctx)
-		//	require.NoError(t, err)
-		//	time.Sleep(2 * time.Second)
-		//	batcherIsUp = false
-		//}
-		//
+		if i == turnBatcherOffIteration {
+			err = driver.StopBatchSubmitting(ctx)
+			require.NoError(t, err)
+			time.Sleep(2 * time.Second)
+			batcherIsUp = false
+		}
+
 		//// Let us start the batcher again
-		//if i == turnBatcherOnIteration {
-		//	err = driver.StartBatchSubmitting()
-		//	require.NoError(t, err)
-		//	batcherIsUp = true
-		//}
+		if i == turnBatcherOnIteration {
+			err = driver.StartBatchSubmitting()
+			require.NoError(t, err)
+			batcherIsUp = true
+		}
 
 		// The batcher is up, we can send coins
 		if batcherIsUp {

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -37,7 +37,7 @@ func TestStatelessBatcher(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, 0)
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -2,17 +2,13 @@ package environment_test
 
 import (
 	"context"
-	"math/big"
-	"math/rand/v2"
-	"testing"
-	"time"
-
 	env "github.com/ethereum-optimism/optimism/espresso/environment"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
 )
 
 // TestStatelessBatcher is a test that verifies a batcher can operate (especially restart) correctly and efficiently without persistent storage.
@@ -79,32 +75,32 @@ func TestStatelessBatcher(t *testing.T) {
 
 	var caffBalanceNew *big.Int
 
-	driver := system.BatchSubmitter.TestDriver()
+	//driver := system.BatchSubmitter.TestDriver()
 	numIterations := 10
 
 	// We select a range of iterations when the batcher is turned off.
-	turnBatcherOffIteration := rand.IntN(numIterations / 2)
-	turnBatcherOnIteration := rand.IntN(numIterations/2) + numIterations/2
+	//turnBatcherOffIteration := rand.IntN(numIterations / 2)
+	//turnBatcherOnIteration := rand.IntN(numIterations/2) + numIterations/2
 
 	batcherIsUp := true
 	for i := 0; i < numIterations; i++ {
 
 		t.Log("******************* Iteration: ", i)
 		//Let us stop the batcher
-		if i == turnBatcherOffIteration {
-
-			err = driver.StopBatchSubmitting(ctx)
-			require.NoError(t, err)
-			time.Sleep(2 * time.Second)
-			batcherIsUp = false
-		}
-
-		// Let us start the batcher again
-		if i == turnBatcherOnIteration {
-			err = driver.StartBatchSubmitting()
-			require.NoError(t, err)
-			batcherIsUp = true
-		}
+		//if i == turnBatcherOffIteration {
+		//
+		//	err = driver.StopBatchSubmitting(ctx)
+		//	require.NoError(t, err)
+		//	time.Sleep(2 * time.Second)
+		//	batcherIsUp = false
+		//}
+		//
+		//// Let us start the batcher again
+		//if i == turnBatcherOnIteration {
+		//	err = driver.StartBatchSubmitting()
+		//	require.NoError(t, err)
+		//	batcherIsUp = true
+		//}
 
 		// The batcher is up, we can send coins
 		if batcherIsUp {

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -97,7 +97,7 @@ func TestStatelessBatcher(t *testing.T) {
 			batcherIsUp = false
 		}
 
-		//// Let us start the batcher again
+		// Let us start the batcher again
 		if i == turnBatcherOnIteration {
 			err = driver.StartBatchSubmitting()
 			require.NoError(t, err)

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -2,16 +2,17 @@ package environment_test
 
 import (
 	"context"
+	"math/big"
+	"math/rand/v2"
+	"testing"
+	"time"
+
 	env "github.com/ethereum-optimism/optimism/espresso/environment"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/helpers"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"math/rand/v2"
-	"testing"
-	"time"
 )
 
 // TestStatelessBatcher is a test that verifies a batcher can operate (especially restart) correctly and efficiently without persistent storage.

--- a/espresso/environment/espresso_dev_net_launcher.go
+++ b/espresso/environment/espresso_dev_net_launcher.go
@@ -15,7 +15,7 @@ type EspressoDevNetLauncher interface {
 	// StartDevNet will launch the DevNet with the provided options. The
 	// returned system will be a fully configured e2e system with the configured
 	// options.
-	StartDevNet(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error)
+	StartDevNet(ctx context.Context, t *testing.T, L1FinalidedDistance uint64, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error)
 }
 
 // DevNetLauncherContext is a struct that contains the context and any errors

--- a/espresso/environment/espresso_dev_node_test.go
+++ b/espresso/environment/espresso_dev_node_test.go
@@ -24,7 +24,7 @@ func TestEspressoDockerDevNodeSmokeTest(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, 0)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -187,7 +187,7 @@ func TestE2eDevNetWithEspressoSimpleTransactions(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, 0)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -211,14 +211,14 @@ func (e EspressoDevNodeContainerInfo) Stop() error {
 // is meant to be.
 var ErrUnableToDetermineEspressoDevNodeSequencerHost = errors.New("unable to determine the host for the espresso-dev-node sequencer api")
 
-func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
+func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *testing.T, L1finalizedDistance uint64, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
 	originalCtx := ctx
 
 	sysConfig := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(config.AllocTypeEspresso))
 
 	// Set a short L1 block time and finalized distance to make tests faster and reach finality sooner
 	sysConfig.DeployConfig.L1BlockTime = 2
-	sysConfig.L1FinalizedDistance = 0
+	sysConfig.L1FinalizedDistance = L1finalizedDistance
 
 	sysConfig.DeployConfig.DeployCeloContracts = true
 

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -215,6 +215,11 @@ func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *test
 	originalCtx := ctx
 
 	sysConfig := e2esys.DefaultSystemConfig(t, e2esys.WithAllocType(config.AllocTypeEspresso))
+
+	// Set a short L1 block time and finalized distance to make tests faster and reach finality sooner
+	sysConfig.DeployConfig.L1BlockTime = 2
+	sysConfig.L1FinalizedDistance = 2
+
 	sysConfig.DeployConfig.DeployCeloContracts = true
 
 	// Ensure that we fund the dev accounts

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -218,7 +218,7 @@ func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *test
 
 	// Set a short L1 block time and finalized distance to make tests faster and reach finality sooner
 	sysConfig.DeployConfig.L1BlockTime = 2
-	sysConfig.L1FinalizedDistance = 2
+	sysConfig.L1FinalizedDistance = 4
 
 	sysConfig.DeployConfig.DeployCeloContracts = true
 

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -218,7 +218,7 @@ func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *test
 
 	// Set a short L1 block time and finalized distance to make tests faster and reach finality sooner
 	sysConfig.DeployConfig.L1BlockTime = 2
-	sysConfig.L1FinalizedDistance = 4
+	sysConfig.L1FinalizedDistance = 0
 
 	sysConfig.DeployConfig.DeployCeloContracts = true
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -279,8 +279,8 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 				continue
 
 			case BatchUndecided:
-				header := (*batch).Header().Hash()
-				s.RemainingBatches[header] = *batch
+				hash := (*batch).Header().Hash()
+				s.RemainingBatches[hash] = *batch
 				continue
 
 			case BatchAccept:

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -80,18 +80,16 @@ func NewEspressoStreamer[B Batch](
 	pollingHotShotPollingInterval time.Duration,
 ) EspressoStreamer[B] {
 	return EspressoStreamer[B]{
-		L1Client:            l1Client,
-		EspressoClient:      espressoClient,
-		EspressoLightClient: lightClient,
-		Log:                 log,
-
+		L1Client:                      l1Client,
+		EspressoClient:                espressoClient,
+		EspressoLightClient:           lightClient,
+		Log:                           log,
 		Namespace:                     namespace,
 		BatchPos:                      1,
 		BatchBuffer:                   NewBatchBuffer[B](),
 		PollingHotShotPollingInterval: pollingHotShotPollingInterval,
 		RemainingBatches:              make(map[common.Hash]B),
-
-		UnmarshalBatch: unmarshalBatch,
+		UnmarshalBatch:                unmarshalBatch,
 	}
 }
 
@@ -105,12 +103,15 @@ func (s *EspressoStreamer[B]) Reset() {
 // Handle both L1 reorgs and batcher restarts by updating our state in case it is
 // not consistent with what's on the L1. Returns true if the state was updated.
 func (s *EspressoStreamer[B]) Refresh(ctx context.Context, syncStatus *eth.SyncStatus) (bool, error) {
-	s.Log.Info("Safe L2 ", "block number", syncStatus.SafeL2.Number)
+	s.Log.Info("L2 ", "safe block number", syncStatus.SafeL2.Number)
+	s.Log.Info("L1 ", "finalized block number", syncStatus.FinalizedL1.Number, "safe block number", syncStatus.SafeL1.Number)
+	s.finalizedL1 = syncStatus.FinalizedL1
+
+	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
 	if s.confirmedBatchPos == syncStatus.SafeL2.Number {
 		return false, nil
 	}
 
-	s.finalizedL1 = syncStatus.FinalizedL1
 	s.confirmedBatchPos = syncStatus.SafeL2.Number
 
 	s.Reset()
@@ -126,8 +127,7 @@ func (s *EspressoStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchVal
 		origin := (batch).L1Origin()
 		if origin.Number > s.finalizedL1.Number {
 			// Signal to resync to wait for the L1 finality.
-			s.Log.Warn("L1 origin not finalized, pending resync", "finalized L1 block number", s.finalizedL1.Number)
-			s.Log.Warn("L1 origin not finalized, pending resync", "origin number", origin.Number)
+			s.Log.Warn("L1 origin not finalized, pending resync", "finalized L1 block number", s.finalizedL1.Number, "origin number", origin.Number)
 			return BatchUndecided, 0
 		}
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -103,6 +103,7 @@ func (s *EspressoStreamer[B]) Reset() {
 // Handle both L1 reorgs and batcher restarts by updating our state in case it is
 // not consistent with what's on the L1. Returns true if the state was updated.
 func (s *EspressoStreamer[B]) Refresh(ctx context.Context, syncStatus *eth.SyncStatus) (bool, error) {
+	s.Log.Info("Refreshing streamer...")
 	s.Log.Info("L2 ", "safe block number", syncStatus.SafeL2.Number)
 	s.Log.Info("L1 ", "finalized block number", syncStatus.FinalizedL1.Number, "safe block number", syncStatus.SafeL1.Number)
 	s.finalizedL1 = syncStatus.FinalizedL1

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -3,10 +3,11 @@ package espresso
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
 	espressoLightClient "github.com/EspressoSystems/espresso-network-go/light-client"

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -3,6 +3,7 @@ package espresso
 import (
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"sync"
 	"time"
@@ -63,6 +64,9 @@ type EspressoStreamer[B Batch] struct {
 	// any out of order.
 	BatchBuffer BatchBuffer[B]
 
+	// Manage the batches which origin is unfinalized
+	RemainingBatches map[common.Hash]B
+
 	UnmarshalBatch func([]byte) (*B, error)
 }
 
@@ -85,6 +89,7 @@ func NewEspressoStreamer[B Batch](
 		BatchPos:                      1,
 		BatchBuffer:                   NewBatchBuffer[B](),
 		PollingHotShotPollingInterval: pollingHotShotPollingInterval,
+		RemainingBatches:              make(map[common.Hash]B),
 
 		UnmarshalBatch: unmarshalBatch,
 	}
@@ -123,7 +128,7 @@ func (s *EspressoStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchVal
 			// Signal to resync to wait for the L1 finality.
 			s.Log.Warn("L1 origin not finalized, pending resync")
 			// TODO uncomment the line below once the remaining list is implemented
-			//return 0, BatchUndecided
+			return 0, BatchUndecided
 		}
 
 		l1header, err := s.L1Client.HeaderByNumber(ctx, new(big.Int).SetUint64(origin.Number))
@@ -131,7 +136,7 @@ func (s *EspressoStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchVal
 			// Signal to resync to be able to fetch the L1 header.
 			s.Log.Warn("Failed to fetch the L1 header, pending resync", "error", err)
 			// TODO uncomment the line below once the remaining list is implemented
-			//return 0, BatchUndecided
+			return 0, BatchUndecided
 		} else {
 			if l1header.Hash() != origin.Hash {
 				s.Log.Warn("Dropping batch with invalid L1 origin hash", "error", err)
@@ -194,6 +199,41 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 
 	i := start
 
+	// Process the remaining batches
+	for k, batch := range s.RemainingBatches {
+
+		validity, pos := s.CheckBatch(ctx, batch)
+
+		switch validity {
+
+		case BatchDrop:
+			s.Log.Warn("Dropping batch", batch)
+			delete(s.RemainingBatches, k)
+			continue
+
+		case BatchPast:
+			s.Log.Warn("Batch already processed. Skipping", "batch", batch)
+			delete(s.RemainingBatches, k)
+			continue
+
+		case BatchUndecided:
+			s.Log.Debug("Batch is still undecided, keeping it in the remaining list", "batch", batch)
+			continue
+
+		case BatchAccept:
+			s.Log.Debug("Recovered batch, inserting")
+
+		case BatchFuture:
+			s.Log.Info("Inserting batch for future processing")
+		}
+
+		s.Log.Trace("Inserting batch into buffer", "batch", batch)
+		delete(s.RemainingBatches, k)
+		s.BatchBuffer.Insert(batch, pos)
+
+	}
+
+	// Process the new batches fetched from Espresso
 	for ; i <= finish; i++ {
 		s.Log.Trace("Fetching HotShot block", "block", i)
 
@@ -234,8 +274,9 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 				s.Log.Info("Batch already processed. Skipping", "batch", batch)
 				continue
 
-			case BatchUndecided: // Sishan TODO: remove if this is not needed
-				// TODO Philippe logic of remaining list
+			case BatchUndecided:
+				header := (*batch).Header().Hash()
+				s.RemainingBatches[header] = *batch
 				continue
 
 			case BatchAccept:

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -127,20 +127,18 @@ func (s *EspressoStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchVal
 		if origin.Number > s.finalizedL1.Number {
 			// Signal to resync to wait for the L1 finality.
 			s.Log.Warn("L1 origin not finalized, pending resync")
-			// TODO uncomment the line below once the remaining list is implemented
-			return 0, BatchUndecided
+			return BatchUndecided, 0
 		}
 
 		l1header, err := s.L1Client.HeaderByNumber(ctx, new(big.Int).SetUint64(origin.Number))
 		if err != nil {
 			// Signal to resync to be able to fetch the L1 header.
 			s.Log.Warn("Failed to fetch the L1 header, pending resync", "error", err)
-			// TODO uncomment the line below once the remaining list is implemented
-			return 0, BatchUndecided
+			return BatchUndecided, 0
 		} else {
 			if l1header.Hash() != origin.Hash {
 				s.Log.Warn("Dropping batch with invalid L1 origin hash", "error", err)
-				return 0, BatchDrop
+				return BatchDrop, 0
 			}
 		}
 	}
@@ -199,6 +197,8 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 
 	i := start
 
+	s.Log.Info("Remaining list before", "Size", len(s.RemainingBatches))
+
 	// Process the remaining batches
 	for k, batch := range s.RemainingBatches {
 
@@ -207,7 +207,7 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 		switch validity {
 
 		case BatchDrop:
-			s.Log.Warn("Dropping batch", batch)
+			s.Log.Warn("Dropping batch", "batch", batch)
 			delete(s.RemainingBatches, k)
 			continue
 
@@ -217,21 +217,23 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 			continue
 
 		case BatchUndecided:
-			s.Log.Debug("Batch is still undecided, keeping it in the remaining list", "batch", batch)
+			s.Log.Warn("Batch is still undecided, keeping it in the remaining list", "batch", batch)
 			continue
 
 		case BatchAccept:
-			s.Log.Debug("Recovered batch, inserting")
+			s.Log.Info("Remaining list", "Recovered batch, inserting batch", batch)
 
 		case BatchFuture:
-			s.Log.Info("Inserting batch for future processing")
+			s.Log.Info("Remaining list", "Inserting batch for future processing", batch)
 		}
 
-		s.Log.Trace("Inserting batch into buffer", "batch", batch)
-		delete(s.RemainingBatches, k)
+		s.Log.Trace("Remaining list", "Inserting batch into buffer", "batch", batch)
 		s.BatchBuffer.Insert(batch, pos)
+		delete(s.RemainingBatches, k)
 
 	}
+
+	s.Log.Info("Remaining list after", "Size", len(s.RemainingBatches))
 
 	// Process the new batches fetched from Espresso
 	for ; i <= finish; i++ {

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -126,7 +126,8 @@ func (s *EspressoStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchVal
 		origin := (batch).L1Origin()
 		if origin.Number > s.finalizedL1.Number {
 			// Signal to resync to wait for the L1 finality.
-			s.Log.Warn("L1 origin not finalized, pending resync")
+			s.Log.Warn("L1 origin not finalized, pending resync", "finalized L1 block number", s.finalizedL1.Number)
+			s.Log.Warn("L1 origin not finalized, pending resync", "origin number", origin.Number)
 			return BatchUndecided, 0
 		}
 
@@ -282,7 +283,7 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 				continue
 
 			case BatchAccept:
-				s.Log.Debug("Recovered batch, inserting")
+				s.Log.Info("Recovered batch, inserting")
 
 			case BatchFuture:
 				s.Log.Info("Inserting batch for future processing")

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
-	espresso "github.com/ethereum-optimism/optimism/espresso"
 	"io"
 	"math"
 	"math/big"
 	_ "net/http/pprof"
 	"sync"
 	"time"
+
+	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
+	espresso "github.com/ethereum-optimism/optimism/espresso"
 
 	"golang.org/x/sync/errgroup"
 

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
+	espresso "github.com/ethereum-optimism/optimism/espresso"
 	"io"
 	"math"
 	"math/big"
@@ -23,12 +25,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	espressoClient "github.com/EspressoSystems/espresso-network-go/client"
 	espressoLightClient "github.com/EspressoSystems/espresso-network-go/light-client"
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	derive "github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -119,6 +120,7 @@ type BatchSubmitter struct {
 	mutex   sync.Mutex
 	running bool
 
+	streamer          espresso.EspressoStreamer[derive.EspressoBatch]
 	txpoolMutex       sync.Mutex // guards txpoolState and txpoolBlockedBlob
 	txpoolState       TxPoolState
 	txpoolBlockedBlob bool
@@ -135,10 +137,25 @@ func NewBatchSubmitter(setup DriverSetup) *BatchSubmitter {
 		state.SetChannelOutFactory(setup.ChannelOutFactory)
 	}
 
-	return &BatchSubmitter{
+	batchSubmitter := &BatchSubmitter{
 		DriverSetup: setup,
 		channelMgr:  state,
 	}
+
+	batchSubmitter.streamer = espresso.NewEspressoStreamer(
+		batchSubmitter.RollupConfig.L2ChainID.Uint64(),
+		batchSubmitter.L1Client,
+		batchSubmitter.Espresso,
+		batchSubmitter.EspressoLightClient,
+		batchSubmitter.Log,
+		func(data []byte) (*derive.EspressoBatch, error) {
+			return derive.UnmarshalEspressoTransaction(data, batchSubmitter.SequencerAddress)
+		},
+		2*time.Second,
+	)
+	log.Info("Streamer started", "streamer", batchSubmitter.streamer)
+
+	return batchSubmitter
 }
 
 func (l *BatchSubmitter) StartBatchSubmitting() error {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -127,18 +127,6 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 	defer ticker.Stop()
 	defer close(publishSignal)
 
-	streamer := espresso.NewEspressoStreamer(
-		l.RollupConfig.L2ChainID.Uint64(),
-		l.L1Client,
-		l.Espresso,
-		l.EspressoLightClient,
-		l.Log,
-		func(data []byte) (*derive.EspressoBatch, error) {
-			return derive.UnmarshalEspressoTransaction(data, l.SequencerAddress)
-		},
-		2*time.Second,
-	)
-
 	for {
 		select {
 		case <-ticker.C:
@@ -148,15 +136,15 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 				continue
 			}
 
-			l.espressoSyncAndRefresh(ctx, newSyncStatus, &streamer)
+			l.espressoSyncAndRefresh(ctx, newSyncStatus, &l.streamer)
 
-			err = streamer.Update(ctx)
+			err = l.streamer.Update(ctx)
 
 			var batch *derive.EspressoBatch
 
 			for {
 
-				batch = streamer.Next(ctx)
+				batch = l.streamer.Next(ctx)
 
 				if batch == nil {
 					break
@@ -184,7 +172,7 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 				if err != nil {
 					l.Log.Error("failed to add L2 block to channel manager", "err", err)
 					l.clearState(ctx)
-					streamer.Reset()
+					l.streamer.Reset()
 				}
 
 				l.Log.Info("Added L2 block to channel manager")

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -180,6 +180,7 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 				}
 
 				l.Log.Info("Added L2 block to channel manager")
+				l.Log.Info("block", "content", block.Body().Transactions)
 			}
 
 			trySignal(publishSignal)

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	espressoCommon "github.com/EspressoSystems/espresso-network-go/types"
-	"github.com/ethereum-optimism/optimism/espresso"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -94,8 +93,8 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 	return nil
 }
 
-func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStatus *eth.SyncStatus, streamer *espresso.EspressoStreamer[derive.EspressoBatch]) {
-	shouldClearState, err := streamer.Refresh(ctx, newSyncStatus)
+func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStatus *eth.SyncStatus) {
+	shouldClearState, err := l.streamer.Refresh(ctx, newSyncStatus)
 	shouldClearState = shouldClearState || err != nil
 
 	l.channelMgrMutex.Lock()
@@ -108,10 +107,10 @@ func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStat
 	l.prevCurrentL1 = newSyncStatus.CurrentL1
 	if syncActions.clearState == nil && shouldClearState {
 		l.channelMgr.Clear(newSyncStatus.SafeL2.L1Origin)
-		streamer.Reset()
+		l.streamer.Reset()
 	} else if syncActions.clearState != nil {
 		l.channelMgr.Clear(*syncActions.clearState)
-		streamer.Reset()
+		l.streamer.Reset()
 	} else {
 		l.channelMgr.PruneSafeBlocks(syncActions.blocksToPrune)
 		l.channelMgr.PruneChannels(syncActions.channelsToPrune)
@@ -136,7 +135,7 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 				continue
 			}
 
-			l.espressoSyncAndRefresh(ctx, newSyncStatus, &l.streamer)
+			l.espressoSyncAndRefresh(ctx, newSyncStatus)
 
 			err = l.streamer.Update(ctx)
 			remainingListLen := len(l.streamer.RemainingBatches)

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -139,6 +139,10 @@ func (l *BatchSubmitter) espressoBatchLoadingLoop(ctx context.Context, wg *sync.
 			l.espressoSyncAndRefresh(ctx, newSyncStatus, &l.streamer)
 
 			err = l.streamer.Update(ctx)
+			remainingListLen := len(l.streamer.RemainingBatches)
+			if remainingListLen > 0 {
+				l.Log.Warn("Remaining list not empty.", "Number items", remainingListLen)
+			}
 
 			var batch *derive.EspressoBatch
 


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1209939621908058?focus=true

### This PR:
Implements the remaining list logic to handle batches which origin is not finalized at the time of processing.

### Key places to review
`espresso/streamer.go`

### How to test this PR
Run test 7.

```
> just remove-espresso-containers 
> just compile-contracts
> go test ./espresso/environment/7_stateless_batcher_test.go -v
```
