### PR TITLE
Better handling for Refresh()

### DIFF
--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -103,7 +103,7 @@ func (s *EspressoStreamer[B]) Refresh(ctx context.Context, finalizedL1 eth.L1Blo
 
 	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
 	if s.fallbackBatchPos == safeBatchNumber {
-		s.BatchPos = s.fallbackBatchPos + 1
+		// This means everything is in sync, no state update needed
 		return false, nil
 	}
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -112,20 +112,6 @@ func (s *EspressoStreamer[B]) Refresh(ctx context.Context, finalizedL1 eth.L1Blo
 	return true, nil
 }
 
-// Sishan TODO: this refresh() is needed before CaffNextBatch, but it is not guaranteed to deal with restarting caff node
-func (s *EspressoStreamer[B]) CaffRefresh(ctx context.Context, finalizedL1Block eth.L1BlockRef, safeBatchNumber uint64) error {
-	s.finalizedL1 = finalizedL1Block
-
-	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
-	if s.fallbackBatchPos == safeBatchNumber {
-		s.BatchPos = s.fallbackBatchPos + 1
-		return nil
-	}
-	s.fallbackBatchPos = safeBatchNumber
-	s.Reset()
-	return nil
-}
-
 func (s *EspressoStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchValidity, int) {
 
 	// Make sure the finalized L1 block is initialized before checking the block number.

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -51,10 +51,8 @@ type EspressoStreamer[B Batch] struct {
 	BatchPos uint64
 	// HotShot block that was visited last
 	hotShotPos uint64
-	// Position of the last safe batch
-	confirmedBatchPos uint64
-	// Hotshot block corresponding to the last safe batch
-	confirmedHotShotPos uint64
+	// Position of the last safe batch, we can use it as the position to fallback when resetting
+	fallbackBatchPos uint64
 	// Latest finalized block on the L1. Used by the batcher, not initialized by the Caff node
 	// until it calls `Refresh`.
 	finalizedL1 eth.L1BlockRef
@@ -94,9 +92,8 @@ func NewEspressoStreamer[B Batch](
 
 // Reset the state to the last safe batch
 func (s *EspressoStreamer[B]) Reset() {
-	s.BatchPos = s.confirmedBatchPos + 1
+	s.BatchPos = s.fallbackBatchPos + 1
 	s.BatchBuffer.Clear()
-	s.confirmEspressoBlockHeight()
 }
 
 // Handle both L1 reorgs and batcher restarts by updating our state in case it is
@@ -108,13 +105,12 @@ func (s *EspressoStreamer[B]) Refresh(ctx context.Context, syncStatus *eth.SyncS
 	s.finalizedL1 = syncStatus.FinalizedL1
 
 	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
-	if s.confirmedBatchPos == syncStatus.SafeL2.Number {
-		s.BatchPos = s.confirmedBatchPos + 1
-		s.confirmedHotShotPos = s.hotShotPos
+	if s.fallbackBatchPos == syncStatus.SafeL2.Number {
+		s.BatchPos = s.fallbackBatchPos + 1
 		return false, nil
 	}
 
-	s.confirmedBatchPos = syncStatus.SafeL2.Number
+	s.fallbackBatchPos = syncStatus.SafeL2.Number
 	s.Reset()
 	return true, nil
 }
@@ -128,9 +124,8 @@ func (s *EspressoStreamer[B]) CaffRefresh(ctx context.Context, parent eth.L2Bloc
 	}
 	s.finalizedL1 = finalizedL1Block
 
-	s.confirmedBatchPos = parent.Number
-	s.BatchPos = s.confirmedBatchPos + 1
-	s.confirmEspressoBlockHeight()
+	s.fallbackBatchPos = parent.Number
+	s.BatchPos = s.fallbackBatchPos + 1
 	return nil
 }
 
@@ -181,7 +176,7 @@ func (s *EspressoStreamer[B]) computeEspressoBlockHeightsRange(ctx context.Conte
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to fetch HotShot block height: %w", err)
 	}
-	start := s.confirmedHotShotPos
+	start := s.hotShotPos
 	finish := min(start+100, currentBlockHeight)
 
 	return start, finish, nil
@@ -308,7 +303,6 @@ func (s *EspressoStreamer[B]) Next(ctx context.Context) *B {
 	// Is the next batch available?
 	if s.HasNext(ctx) {
 		s.BatchPos += 1
-		s.confirmEspressoBlockHeight()
 		return s.BatchBuffer.Pop()
 	}
 
@@ -321,10 +315,4 @@ func (s *EspressoStreamer[B]) HasNext(ctx context.Context) bool {
 	}
 
 	return false
-}
-
-// This function allows to "pin" the Espresso block height corresponding to the last safe batch
-// Note that this function can be called
-func (s *EspressoStreamer[B]) confirmEspressoBlockHeight() {
-	s.confirmedHotShotPos = s.hotShotPos
 }

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -98,11 +98,8 @@ func (s *EspressoStreamer[B]) Reset() {
 
 // Handle both L1 reorgs and batcher restarts by updating our state in case it is
 // not consistent with what's on the L1. Returns true if the state was updated.
-func (s *EspressoStreamer[B]) Refresh(ctx context.Context, syncStatus *eth.SyncStatus) (bool, error) {
-	s.Log.Info("Refreshing streamer...")
-	s.Log.Info("L2 ", "safe block number", syncStatus.SafeL2.Number)
-	s.Log.Info("L1 ", "finalized block number", syncStatus.FinalizedL1.Number, "safe block number", syncStatus.SafeL1.Number)
-	s.finalizedL1 = syncStatus.FinalizedL1
+func (s *EspressoStreamer[B]) Refresh(ctx context.Context, finalizedL1 eth.L1BlockRef, syncStatus *eth.SyncStatus) (bool, error) {
+	s.finalizedL1 = finalizedL1
 
 	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
 	if s.fallbackBatchPos == syncStatus.SafeL2.Number {
@@ -116,16 +113,18 @@ func (s *EspressoStreamer[B]) Refresh(ctx context.Context, syncStatus *eth.SyncS
 }
 
 // Sishan TODO: this refresh() is needed before CaffNextBatch, but it is not guaranteed to deal with restarting caff node
-func (s *EspressoStreamer[B]) CaffRefresh(ctx context.Context, parent eth.L2BlockRef, l1Finalized func() (eth.L1BlockRef, error)) error {
-	finalizedL1Block, err := l1Finalized()
-	if err != nil {
-		s.Log.Error("failed to get the L1 finalized block", "err", err)
-		return err
-	}
+func (s *EspressoStreamer[B]) CaffRefresh(ctx context.Context, finalizedL1Block eth.L1BlockRef, parent eth.L2BlockRef) error {
 	s.finalizedL1 = finalizedL1Block
 
+	s.Log.Info("CaffRefresh", "s.fallbackBatchPos", s.fallbackBatchPos, "parent.Number", parent.Number)
+	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
+	if s.fallbackBatchPos == parent.Number {
+		s.BatchPos = s.fallbackBatchPos + 1
+		return nil
+	}
 	s.fallbackBatchPos = parent.Number
 	s.BatchPos = s.fallbackBatchPos + 1
+	// s.Reset()
 	return nil
 }
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -98,33 +98,31 @@ func (s *EspressoStreamer[B]) Reset() {
 
 // Handle both L1 reorgs and batcher restarts by updating our state in case it is
 // not consistent with what's on the L1. Returns true if the state was updated.
-func (s *EspressoStreamer[B]) Refresh(ctx context.Context, finalizedL1 eth.L1BlockRef, syncStatus *eth.SyncStatus) (bool, error) {
+func (s *EspressoStreamer[B]) Refresh(ctx context.Context, finalizedL1 eth.L1BlockRef, safeBatchNumber uint64) (bool, error) {
 	s.finalizedL1 = finalizedL1
 
 	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
-	if s.fallbackBatchPos == syncStatus.SafeL2.Number {
+	if s.fallbackBatchPos == safeBatchNumber {
 		s.BatchPos = s.fallbackBatchPos + 1
 		return false, nil
 	}
 
-	s.fallbackBatchPos = syncStatus.SafeL2.Number
+	s.fallbackBatchPos = safeBatchNumber
 	s.Reset()
 	return true, nil
 }
 
 // Sishan TODO: this refresh() is needed before CaffNextBatch, but it is not guaranteed to deal with restarting caff node
-func (s *EspressoStreamer[B]) CaffRefresh(ctx context.Context, finalizedL1Block eth.L1BlockRef, parent eth.L2BlockRef) error {
+func (s *EspressoStreamer[B]) CaffRefresh(ctx context.Context, finalizedL1Block eth.L1BlockRef, safeBatchNumber uint64) error {
 	s.finalizedL1 = finalizedL1Block
 
-	s.Log.Info("CaffRefresh", "s.fallbackBatchPos", s.fallbackBatchPos, "parent.Number", parent.Number)
 	// NOTE: be sure to update s.finalizedL1 before checking this condition and returning
-	if s.fallbackBatchPos == parent.Number {
+	if s.fallbackBatchPos == safeBatchNumber {
 		s.BatchPos = s.fallbackBatchPos + 1
 		return nil
 	}
-	s.fallbackBatchPos = parent.Number
-	s.BatchPos = s.fallbackBatchPos + 1
-	// s.Reset()
+	s.fallbackBatchPos = safeBatchNumber
+	s.Reset()
 	return nil
 }
 
@@ -301,6 +299,8 @@ func (s *EspressoStreamer[B]) Update(ctx context.Context) error {
 func (s *EspressoStreamer[B]) Next(ctx context.Context) *B {
 	// Is the next batch available?
 	if s.HasNext(ctx) {
+		// Current batch is going to be processed, update fallback batch position
+		s.fallbackBatchPos = s.BatchPos
 		s.BatchPos += 1
 		return s.BatchBuffer.Pop()
 	}

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -95,7 +95,7 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 }
 
 func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStatus *eth.SyncStatus) {
-	shouldClearState, err := l.streamer.Refresh(ctx, newSyncStatus.FinalizedL1, newSyncStatus)
+	shouldClearState, err := l.streamer.Refresh(ctx, newSyncStatus.FinalizedL1, newSyncStatus.SafeL2.Number)
 	shouldClearState = shouldClearState || err != nil
 
 	l.channelMgrMutex.Lock()

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -95,7 +95,7 @@ func (l *BatchSubmitter) queueBlockToEspresso(ctx context.Context, block *types.
 }
 
 func (l *BatchSubmitter) espressoSyncAndRefresh(ctx context.Context, newSyncStatus *eth.SyncStatus) {
-	shouldClearState, err := l.streamer.Refresh(ctx, newSyncStatus)
+	shouldClearState, err := l.streamer.Refresh(ctx, newSyncStatus.FinalizedL1, newSyncStatus)
 	shouldClearState = shouldClearState || err != nil
 
 	l.channelMgrMutex.Lock()

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -117,11 +117,11 @@ func (aq *AttributesQueue) Origin() eth.L1BlockRef {
 
 // CaffNextBatch fetches the next batch from the Espresso streamer for the caff node.
 //
-// It follows the flow: CaffRefresh() -> Update() -> Next().
+// It follows the flow: Refresh() -> Update() -> Next().
 //
 // This is similar to the batcher's flow: espressoBatchLoadingLoop -> getSyncStatus -> refresh -> Update -> Next,
 // but with a few key differences:
-// - CaffNextBatch uses its own refresh logic (CaffRefresh) because it obtains sync state differently from the batcher.
+// - CaffNextBatch obtains sync state differently from the batcher, it treated parent.Number() as the latest safe batch number.
 // - It only calls Update() when needed and everytime only calls Next() once. While the batcher calls Next() in a loop.
 // - It performs additional checks, such as validating the timestamp and parent hash, which does not apply to the batcher.
 func CaffNextBatch(s *espresso.EspressoStreamer[EspressoBatch], ctx context.Context, parent eth.L2BlockRef, blockTime uint64, l1Finalized func() (eth.L1BlockRef, error), l1BlockRefByNumber func(context.Context, uint64) (eth.L1BlockRef, error)) (*SingularBatch, bool, error) {
@@ -131,10 +131,11 @@ func CaffNextBatch(s *espresso.EspressoStreamer[EspressoBatch], ctx context.Cont
 		s.Log.Error("failed to get the L1 finalized block", "err", err)
 		return nil, false, err
 	}
-	if err := s.CaffRefresh(ctx, finalizedL1Block, parent.Number); err != nil {
+	if _, err := s.Refresh(ctx, finalizedL1Block, parent.Number); err != nil {
 		return nil, false, err
 	}
 
+	// Update the streamer if needed
 	if !s.HasNext(ctx) {
 		err := s.Update(ctx)
 		if err != nil {
@@ -142,6 +143,7 @@ func CaffNextBatch(s *espresso.EspressoStreamer[EspressoBatch], ctx context.Cont
 		}
 	}
 
+	// Get the next batch
 	var espressoBatch = s.Next(ctx)
 
 	if espressoBatch == nil {

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -126,7 +126,12 @@ func (aq *AttributesQueue) Origin() eth.L1BlockRef {
 // - It performs additional checks, such as validating the timestamp and parent hash, which does not apply to the batcher.
 func CaffNextBatch(s *espresso.EspressoStreamer[EspressoBatch], ctx context.Context, parent eth.L2BlockRef, blockTime uint64, l1Finalized func() (eth.L1BlockRef, error), l1BlockRefByNumber func(context.Context, uint64) (eth.L1BlockRef, error)) (*SingularBatch, bool, error) {
 	// Refresh the sync status
-	if err := s.CaffRefresh(ctx, parent, l1Finalized); err != nil {
+	finalizedL1Block, err := l1Finalized()
+	if err != nil {
+		s.Log.Error("failed to get the L1 finalized block", "err", err)
+		return nil, false, err
+	}
+	if err := s.CaffRefresh(ctx, finalizedL1Block, parent); err != nil {
 		return nil, false, err
 	}
 

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -131,7 +131,7 @@ func CaffNextBatch(s *espresso.EspressoStreamer[EspressoBatch], ctx context.Cont
 		s.Log.Error("failed to get the L1 finalized block", "err", err)
 		return nil, false, err
 	}
-	if err := s.CaffRefresh(ctx, finalizedL1Block, parent); err != nil {
+	if err := s.CaffRefresh(ctx, finalizedL1Block, parent.Number); err != nil {
 		return nil, false, err
 	}
 


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209393353274209/task/1210114467360881?focus=true
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- Renames `confirmedBatchPos` to `fallbackBatchPos`
- Assigns `fallbackBatchPos` everytime when we derive a new batch (I think there could be a bug if we don't do this)
- Removes `confirmedHotShotPos`, now we consistently use `hotShotPos` wherever needed
- Merges `Refresh()` for caff node and the batcher
- Adds more comments
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
- Refresh() in `espresso/streamer.go`
- [line 289](https://github.com/EspressoSystems/optimism-espresso-integration/pull/121/files#diff-1912bc32db1ca7d02cb1784e7e053dc6d5a6e91043028c8160d48afaf23d2d3fR288-R289) in `espresso/streamer.go`: Assign `fallbackBatchPos` everytime when we derive a new batch (I think there could be a bug if we don't do this) 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210114467360891