### PR TITLE
Fix test 7

### DIFF
--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -3,6 +3,7 @@ package environment_test
 import (
 	"context"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"math/rand/v2"
 	"testing"
@@ -89,6 +90,8 @@ func TestStatelessBatcher(t *testing.T) {
 
 	numIterations := 8
 
+	var txHashes []common.Hash
+
 	// We select a range of iterations when the batcher is turned off.
 	restartIteration := 1 + rand.IntN(numIterations-1)
 	for i := 0; i < numIterations; i++ {
@@ -99,6 +102,8 @@ func TestStatelessBatcher(t *testing.T) {
 		t.Log("******************* Iteration: ", i)
 		//Let us stop the batcher
 		if i == restartIteration {
+
+			t.Log("+++++++++++++++++ Iteration with batcher restart: ", i)
 			// Stop the batcher
 			err = driver.StopBatchSubmitting(ctx)
 			require.NoError(t, err)
@@ -145,7 +150,8 @@ func TestStatelessBatcher(t *testing.T) {
 
 		} else {
 			// The batcher is up, we can send coins
-			env.RunSimpleL2Transfer(ctx, t, system, nonce, *amount, l2Seq, l2Verif)
+			txHash := env.RunSimpleL2Transfer(ctx, t, system, nonce, *amount, l2Seq)
+			txHashes = append(txHashes, txHash)
 		}
 
 		// There should be a transfer for each iteration
@@ -156,6 +162,12 @@ func TestStatelessBatcher(t *testing.T) {
 	numDepositsBigInt.SetInt64(int64(numTransfers))
 
 	expectedAmount := new(big.Int).Mul(new(big.Int).Add(balanceAliceInitial, &numDepositsBigInt), amount)
+
+	// Wait for the transfers to be processed
+	for _, hash := range txHashes {
+		_, err := wait.ForReceiptOK(ctx, l2Verif, hash)
+		require.NoError(t, err)
+	}
 
 	caffBalanceNew, _ = caffVerif.BalanceAt(ctx, addressAlice, nil)
 	l2BalanceNew, _ := l2Verif.BalanceAt(ctx, addressAlice, nil)

--- a/espresso/environment/tx_helpers.go
+++ b/espresso/environment/tx_helpers.go
@@ -18,7 +18,13 @@ import (
 
 // runSimpleL2Transfer runs a simple L2 burn transaction and verifies it on the
 // L2 Verifier.
-func RunSimpleL2Transfer(ctx context.Context, t *testing.T, system *e2esys.System, nonce uint64, amount big.Int, l2Seq *ethclient.Client, l2Verif *ethclient.Client) {
+func RunSimpleL2Transfer(
+	ctx context.Context,
+	t *testing.T,
+	system *e2esys.System,
+	nonce uint64,
+	amount big.Int,
+	l2Seq *ethclient.Client) common.Hash {
 	_, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -28,21 +34,20 @@ func RunSimpleL2Transfer(ctx context.Context, t *testing.T, system *e2esys.Syste
 
 	destAddress := system.Cfg.Secrets.Addresses().Alice
 
-	receipt := helpers.SendL2Tx(
-		t,
-		system.Cfg,
-		l2Seq,
-		privateKey,
-		L2TxWithOptions(
-			L2TxWithAmount(&amount),
-			L2TxWithNonce(nonce),
-			L2TxWithToAddress(&destAddress),
-			L2TxWithVerifyOnClients(l2Verif),
-		),
-	)
+	receipt := helpers.SendL2TxWithID(t, system.Cfg.L2ChainIDBig(), l2Seq, privateKey, func(opts *helpers.TxOpts) {
+		opts.Nonce = nonce
+		opts.ToAddr = &destAddress
+		opts.Value = &amount
+	})
+
 	t.Log("Receipt", receipt)
 
 	cancel()
+
+	txHash := receipt.TxHash
+
+	return txHash
+
 }
 
 // runSimpleL1TransferAndVerifier runs a simple L1 transfer and verifies it on


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1210323348785282?focus=true

### This PR:

Fixes the intermittent bug in test 7. The main problem of this test was that for each iteration we were waiting for the transaction receipt. During this wait, the L2 sequencer keeps making progress at a high pace, which means that for the next iteration the wait might be longer. In order to make the test faster, we wait now wait for the transaction receipts only after all the iterations are done. The test is now faster (takes around 2 minutes to run) and I did not observe any test failure after 10 runs in a row.

### This PR does not:
Change anything about the logic of the streamer/batcher.

### Key places to review:

File `espresso/environment/7_stateless_batcher_test.go`

### How to test this PR:  

```
just run-test7
```

