### PR TITLE
Fix panic error in test TestCaffNodeWaitForFinality

### DIFF
--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -63,6 +63,14 @@ func (b *BatchBuffer[B]) TryInsert(batch B) (int, bool) {
 
 }
 
+func (b *BatchBuffer[B]) Get(i int) *B {
+	if i < b.Len() {
+		return &b.batches[i]
+	} else {
+		return nil
+	}
+}
+
 func (b *BatchBuffer[B]) Peek() *B {
 	if len(b.batches) == 0 {
 		return nil

--- a/espresso/environment/8_reorg_test.go
+++ b/espresso/environment/8_reorg_test.go
@@ -84,8 +84,8 @@ func TestBatcherWaitForFinality(t *testing.T) {
 // VerifyL1OriginFinalized checks whether every batch in the batch buffer has a finalized L1
 // origin.
 func VerifyL1OriginFinalized(t *testing.T, streamer *espresso.EspressoStreamer[derive.EspressoBatch], l1Client *ethclient.Client) bool {
-	batch := streamer.BatchBuffer.Pop()
-	for batch != nil {
+	for i := 0; i < streamer.BatchBuffer.Len(); i++ {
+		batch := streamer.BatchBuffer.Get(i)
 		origin := (batch).L1Origin()
 		finalizedL1, err := l1Client.BlockByNumber(context.Background(), big.NewInt(rpc.FinalizedBlockNumber.Int64()))
 		if err != nil {
@@ -98,7 +98,6 @@ func VerifyL1OriginFinalized(t *testing.T, streamer *espresso.EspressoStreamer[d
 			t.Log("L1 origin not finalized", "origin", origin.Number, "FinalizedL1", finalizedL1.NumberU64())
 			return false
 		}
-		batch = streamer.BatchBuffer.Pop()
 	}
 	return true
 }


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1210382352176310?focus=true

### This PR:
Fixes a bug in the test `TestCaffNodeWaitForFinality`. The problem was that the test was updating (by calling `BatchBuffer.Pop()`) the batch buffer of the caff node streamer, creating a race condition.
The fix consists of adding a read only getter to the `BatchBuffer` struct in order to be able to verify the content of the BatchBuffer without modifying it.


### Key places to review:
All changes.

### How to test this PR: 
```
just compile-contracts
go test  ./espresso/environment/8_reorg_test.go -run="^TestCaffNodeWaitForFinality$" -v -count=20
```


