### PR TITLE
Handling of BatchFuture validity constant for batches in the Streamer

### DIFF
--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -343,7 +343,8 @@ func (s *EspressoStreamer[B]) processRemainingBatches(ctx context.Context) {
 			s.Log.Info("Remaining list", "Recovered batch, inserting batch", batch)
 
 		case BatchFuture:
-			s.Log.Info("Remaining list", "Inserting batch for future processing", batch)
+			// The function CheckBatch is not expected to return BatchFuture so if we enter this case there is a problem.
+			s.Log.Error("Remaining list", "BatchFuture validity not expected for batch", batch)
 		}
 
 		s.Log.Trace("Remaining list", "Inserting batch into buffer", "batch", batch)
@@ -386,7 +387,8 @@ func (s *EspressoStreamer[B]) processEspressoTransactions(ctx context.Context, i
 			s.Log.Info("Inserting accepted batch")
 
 		case BatchFuture:
-			s.Log.Info("Inserting batch for future processing")
+			// The function CheckBatch is not expected to return BatchFuture so if we enter this case there is a problem.
+			s.Log.Error("Remaining list", "BatchFuture validity not expected for batch", batch)
 		}
 
 		s.Log.Trace("Inserting batch into buffer", "batch", batch)


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1210114467360887?focus=true

### This PR:
Increases the log level to Error if a batch is assigned the `BatchFuture` constant after verification as this should not happen.

### Key places to review:
All changes.

### How to test this PR: 
```
just espresso-tests
```