### PR TITLE
Pinpoint go version in nix to 1.22.7

### DIFF
--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -51,12 +51,6 @@ To run a subset of the tests above (fast):
 
 > just fast-tests
 
-
-
-If in the Nix environment, any `just` command fails with a tool version mismatch error such as
-`version "go1.22.7" does not match go tool version "go1.22.12"`, use
-`export GOROOT="$(dirname $(dirname $(which go)))/share/go"` to set the expected Go version.
-
 ### Run the Kurtosis devnet
 
 - Install tools.

--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -171,7 +171,7 @@ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
 source ~/.bashrc
 ```
 
-* Git, Nitro, Docker
+* Git, Docker
 ```
  sudo yum update
  sudo yum install git
@@ -179,9 +179,21 @@ source ~/.bashrc
  sudo usermod -a -G docker ec2-user
  sudo service docker start
  sudo chown ec2-user /var/run/docker.sock
- sudo dnf install aws-nitro-enclaves-cli -y
- sudo systemctl start nitro-enclaves-allocator.service
 ```
+
+* Nitro
+
+These commands install the dependencies for, start the service related to and configures the enclave.
+
+```
+sudo dnf install aws-nitro-enclaves-cli -y
+sudo systemctl start nitro-enclaves-allocator.service
+sudo sh -c "echo -e 'memory_mib: 4096\ncpu_count: 2' > /etc/nitro_enclaves/allocator.yaml"
+```
+
+
+
+/etc/nitro_enclaves/allocator.yaml
 
 * Clone repository and update submodules
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,6 @@
 
            src = pkgs.fetchurl {
              url = "https://go.dev/dl/go1.22.7.src.tar.gz";
-             # temporarily set to zero hash to get the expected hash
              sha256 = "sha256-ZkMth9heDPrD7f/mN9WTD8Td9XkzE/4R5KDzMwI8h58=";
            };
          });

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,17 @@
         overlays = [
           inputs.foundry.overlay
         ];
+
+         go_1_22_7 = pkgs.go_1_22.overrideAttrs (oldAttrs: rec {
+           version = "1.22.7";
+
+           src = pkgs.fetchurl {
+             url = "https://go.dev/dl/go1.22.7.src.tar.gz";
+             # temporarily set to zero hash to get the expected hash
+             sha256 = "sha256-ZkMth9heDPrD7f/mN9WTD8Td9XkzE/4R5KDzMwI8h58=";
+           };
+         });
+
         espresso_go_lib_version = "v0.0.35";
         pkgs = import inputs.nixpkgs { inherit overlays system; };
         espressoGoLibFile =
@@ -67,8 +78,11 @@
           buildAndTestSubdir = cargoRoot;
         };
 
+
+
       in
       {
+
         formatter = pkgs.nixfmt-rfc-style;
 
         devShell = pkgs.mkShell {
@@ -81,7 +95,7 @@
             pkgs.python311
             pkgs.foundry-bin
             pkgs.just
-            pkgs.go_1_22
+            go_1_22_7
             pkgs.gotools
             pkgs.go-ethereum
             pkgs.golangci-lint


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1210415118754762?focus=true

### This PR:
Updates flake.nix in order to pinpoint the go version to 1.22.7 as required in https://github.com/EspressoSystems/optimism-espresso-integration/blob/a0cc3f638696f5106bb3a070ccf00ca9c9fa305a/go.mod#L5

NOTE: this PR also updates the README_ESPRESSO.md file about the setup of the enclave. This is not related to the problem mentioned in the ticket but was missing to be able to run the enclave tests properly.

### Key places to review:
`flake.nix` file.

### How to test this PR:  
```
just espresso-tests
```