### PR TITLE
Fix kurtosis devnet and Reduce CI flakiness

### DIFF
--- a/.github/workflows/espresso-enclave.yaml
+++ b/.github/workflows/espresso-enclave.yaml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   enclave-tests-on-ec2:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     steps:
 

--- a/espresso/environment/1_espresso_benchmark_test.go
+++ b/espresso/environment/1_espresso_benchmark_test.go
@@ -137,11 +137,11 @@ func TestE2eDevNetWithEspressoFastConfirmationStability(t *testing.T) {
 		}
 
 		// We do not expect a signification amount of variance or std deviation
-		if have, want := metrics.SubmittedToReceipt.StdDev, 2*time.Second; have > want {
+		if have, want := metrics.SubmittedToReceipt.StdDev, 3*time.Second; have > want {
 			t.Errorf("expected a small amount of variance in the submitted to receipt time:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 		}
 
-		if have, want := metrics.ReceiptToCaff.StdDev, 2*time.Second; have > want {
+		if have, want := metrics.ReceiptToCaff.StdDev, 3*time.Second; have > want {
 			t.Errorf("expected a small amount of variance in the receipt to caff time:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 		}
 

--- a/kurtosis-devnet/espresso.yaml
+++ b/kurtosis-devnet/espresso.yaml
@@ -45,7 +45,9 @@ optimism_package:
         image: {{ localDockerImage "op-batcher" }}
         extra_params:
           - "--espresso-url=http://op-espresso-devnode:24000"
+          - "--espresso-url=http://op-espresso-devnode:24000"
           - "--espresso-light-client-addr=0x703848f4c85f18e3acd8196c8ec91eb0b7bd0797"
+          - "--testing-espresso-batcher-private-key=0xb3d2d558e3491a3709b7c451100a0366b5872520c7aa020c17a0e7fa35b6a8df"
       challenger_params:
         image: {{ localDockerImage "op-challenger" }}
         cannon_prestate_path: ""
@@ -73,8 +75,6 @@ optimism_package:
   global_node_selectors: {}
   global_tolerations: []
   persistent: false
-  observability:
-    enabled: false
 ethereum_package:
   participants:
     - el_type: geth

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -100,10 +100,10 @@ enter-devnet DEVNET CHAIN='Ethereum' NODE_INDEX='0':
     exec go run ../devnet-sdk/shell/cmd/enter/main.go --devnet kt://{{DEVNET}} --chain {{CHAIN}} --node-index {{NODE_INDEX}}
 
 # Espresso devnet
-espresso-devnet: (devnet "espresso.yaml" "" "" "github.com/EspressoSystems/espresso-optimism-package")
+espresso-devnet: (devnet "espresso.yaml")
 
 # Espresso devnet with external batcher
-espresso-eb-devnet: (devnet "espresso-eb.yaml" "" "" "github.com/EspressoSystems/espresso-optimism-package")
+espresso-eb-devnet: (devnet "espresso-eb.yaml")
 
 # Start an external batcher (assuming espresso-eb-devnet is running)
 external-batcher:

--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -2,7 +2,11 @@ name: github.com/ethereum-optimism/optimism/kurtosis-devnet/optimism-package-tra
 description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
-  github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@1cf76907eaa437ee9fcf902167714fece027962a
+  # Package history of optimism-package:
+  # - Original: github.com/ethpandaops/optimism-package@1cf76907eaa437ee9fcf902167714fece027962a
+  # - Current: Espresso version rebased on top of original
+  # - Commit: one commit of branch sishan/rebase-1cf7690 https://github.com/EspressoSystems/espresso-optimism-package/tree/sishan/rebase-1cf7690
+  github.com/ethpandaops/optimism-package: github.com/EspressoSystems/espresso-optimism-package@fb760e94c0021a349a5bbffefe1f4af596b8bc7b
   github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -163,7 +163,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 			// Replace ephemeral keys with configured keys, as in devnet they'll be pre-approved for batching
 			privateKey, err := crypto.HexToECDSA(strings.TrimPrefix(cfg.TestingEspressoBatcherPrivateKey, "0x"))
 			if err != nil {
-				return fmt.Errorf("Failed to parse batcher's private key (%v): %w", cfg.TestingEspressoBatcherPrivateKey, err)
+				return fmt.Errorf("failed to parse batcher's testing private key (%v): %w", cfg.TestingEspressoBatcherPrivateKey, err)
 			}
 
 			publicKey := privateKey.Public()


### PR DESCRIPTION

Redo changes in https://github.com/EspressoSystems/optimism-espresso-integration/pull/191 and https://github.com/EspressoSystems/optimism-espresso-integration/pull/195 as we haven't moved them to the new default branch `celo-integration-rebase-13.2`.
