### PR TITLE
AF1.3 Fix invalid length check

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -138,7 +138,8 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	}
 	opts = append(optsFromRPC, opts...)
 
-	if len(cfg.EspressoUrls) > 0 {
+	// MultipleNodesClient requires at least 2 URLs.
+	if len(cfg.EspressoUrls) > 1 {
 		bs.EspressoPollInterval = cfg.EspressoPollInterval
 		client, err := espressoClient.NewMultipleNodesClient(cfg.EspressoUrls)
 		if err != nil {


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211106994726396?focus=true.

### This PR:
* Fixes the length check for the `MultipleNodesClient` URLs.