### PR TITLE
AF1.4 Fix missing check for batch insertion on error

### DIFF
--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -348,6 +348,7 @@ func (s *EspressoStreamer[B]) processRemainingBatches(ctx context.Context) {
 		case BatchFuture:
 			// The function CheckBatch is not expected to return BatchFuture so if we enter this case there is a problem.
 			s.Log.Error("Remaining list", "BatchFuture validity not expected for batch", batch)
+			continue
 		}
 
 		s.Log.Trace("Remaining list", "Inserting batch into buffer", "batch", batch)
@@ -397,6 +398,7 @@ func (s *EspressoStreamer[B]) processEspressoTransactions(ctx context.Context, i
 		case BatchFuture:
 			// The function CheckBatch is not expected to return BatchFuture so if we enter this case there is a problem.
 			s.Log.Error("Remaining list", "BatchFuture validity not expected for batch", batch)
+			continue
 		}
 
 		s.Log.Trace("Inserting batch into buffer", "batch", batch)


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211106994726408?focus=true.

### This PR:
* Skips inserting a batch in the case of `BatchFuture`.