### PR TITLE
IA1.5.5 Fix L2 genesis initialization

### DIFF
--- a/espresso/docker/op-geth/op-geth-init.sh
+++ b/espresso/docker/op-geth/op-geth-init.sh
@@ -17,7 +17,9 @@ if [ "$MODE" = "genesis" ]; then
   op-deployer inspect genesis --workdir /deployer --outfile /config/genesis.json $L2_CHAIN_ID
 
   echo "Updating genesis timestamp..."
-  dasel put -f /config/genesis.json -s .timestamp -v $(printf '0x%x\n' $(date +%s))
+  # Use environment variable or fallback to the current time.
+  GENESIS_TIMESTAMP=${GENESIS_TIMESTAMP:-$(printf '0x%x\n' $(date +%s))}
+  dasel put -f /config/genesis.json -s .timestamp -v "$GENESIS_TIMESTAMP"
 
   if [[ ! -f /config/jwt.txt ]]; then
       echo "Generating JWT token..."


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211163198780446?focus=true.

### This PR:
- Adds an environment variable to override the L2 genesis timestamp.