### PR TITLE
Make Docker images work cross-platform

### DIFF
--- a/espresso/docker/l1-geth/Dockerfile
+++ b/espresso/docker/l1-geth/Dockerfile
@@ -27,47 +27,47 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
-  curl \
-  jq \
-  ca-certificates \
-  openssl \
-  && rm -rf /var/lib/apt/lists/*
+    curl \
+    jq \
+    ca-certificates \
+    openssl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install dasel for JSON manipulation
-RUN curl -sSL "https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_amd64" -o /usr/local/bin/dasel && \
+RUN curl -sSL "https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_$(dpkg --print-architecture)" -o /usr/local/bin/dasel && \
     chmod +x /usr/local/bin/dasel
 
 # Install yq for YAML parsing
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)" -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
 # Install Geth for the given architecture.
 RUN ARCH=$(dpkg --print-architecture) && \
-  echo "Detected architecture: $ARCH" && \
-  case "$ARCH" in \
-  "amd64") \
-  GETH_URL="https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.15.11-36b2371c.tar.gz" && \
-  GETH_SHA="a14a4285daedf75ea04a7a298e6caa48d566a2786c93fc5e86ec2c5998c92455" && \
-  GETH_DIR="geth-linux-amd64-1.15.11-36b2371c" && \
-  VERIFY_SHA="true" \
-  ;; \
-  "arm64") \
-  GETH_URL="https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.15.11-36b2371c.tar.gz" && \
-  GETH_SHA="148ec84db2268fa846ae68f6445f0c98d33e95069e40fe8c74b43ea5eb53df7b" && \
-  GETH_DIR="geth-linux-arm64-1.15.11-36b2371c" && \
-  VERIFY_SHA="true" \
-  ;; \
-  *) \
-  echo "Unsupported architecture: $ARCH" && exit 1 \
-  ;; \
-  esac && \
-  echo "Downloading: $GETH_URL" && \
-  curl -L "$GETH_URL" -o geth.tar.gz && \
-  echo "$GETH_SHA geth.tar.gz" | sha256sum -c - && \
-  tar -xvf geth.tar.gz && \
-  mv "$GETH_DIR/geth" /usr/local/bin/geth && \
-  rm -rf geth.tar.gz "$GETH_DIR" && \
-  chmod +x /usr/local/bin/geth
+    echo "Detected architecture: $ARCH" && \
+    case "$ARCH" in \
+    "amd64") \
+    GETH_URL="https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.15.11-36b2371c.tar.gz" && \
+    GETH_SHA="a14a4285daedf75ea04a7a298e6caa48d566a2786c93fc5e86ec2c5998c92455" && \
+    GETH_DIR="geth-linux-amd64-1.15.11-36b2371c" && \
+    VERIFY_SHA="true" \
+    ;; \
+    "arm64") \
+    GETH_URL="https://gethstore.blob.core.windows.net/builds/geth-linux-arm64-1.15.11-36b2371c.tar.gz" && \
+    GETH_SHA="148ec84db2268fa846ae68f6445f0c98d33e95069e40fe8c74b43ea5eb53df7b" && \
+    GETH_DIR="geth-linux-arm64-1.15.11-36b2371c" && \
+    VERIFY_SHA="true" \
+    ;; \
+    *) \
+    echo "Unsupported architecture: $ARCH" && exit 1 \
+    ;; \
+    esac && \
+    echo "Downloading: $GETH_URL" && \
+    curl -L "$GETH_URL" -o geth.tar.gz && \
+    echo "$GETH_SHA geth.tar.gz" | sha256sum -c - && \
+    tar -xvf geth.tar.gz && \
+    mv "$GETH_DIR/geth" /usr/local/bin/geth && \
+    rm -rf geth.tar.gz "$GETH_DIR" && \
+    chmod +x /usr/local/bin/geth
 
 # Install lighthouse consensus tools
 RUN curl -sSL "https://github.com/sigp/lighthouse/releases/download/v5.3.0/lighthouse-v5.3.0-x86_64-unknown-linux-gnu.tar.gz" -o lighthouse.tar.gz && \

--- a/espresso/docker/op-geth/Dockerfile
+++ b/espresso/docker/op-geth/Dockerfile
@@ -59,8 +59,12 @@ RUN echo "Cache bust: $(date)" > /cache-bust.txt
 RUN apk add curl jq openssl
 
 # Install dasel for JSON manipulation.
-RUN curl -sSL "https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_amd64" -o /usr/local/bin/dasel && \
-    chmod +x /usr/local/bin/dasel
+RUN case $(uname -m) in \
+  "arm64"|"aarch64") ARCH="arm64" ;; \
+  *) ARCH="amd64" ;; \
+  esac && \
+  curl -sSL "https://github.com/TomWright/dasel/releases/latest/download/dasel_linux_$ARCH" -o /usr/local/bin/dasel && \
+  chmod +x /usr/local/bin/dasel
 
 # Copy binary from builder stage.
 COPY --from=op-deployer-builder /op-deployer /usr/local/bin/

--- a/espresso/docker/op-stack/Dockerfile
+++ b/espresso/docker/op-stack/Dockerfile
@@ -64,7 +64,12 @@ FROM alpine:3.22 AS op-cgo-builder
 RUN apk add musl-dev gcc go g++ curl tar gzip make gcc linux-headers git jq bash yq
 # Install just from mise
 COPY ./mise.toml .
-RUN curl -L https://github.com/casey/just/releases/download/$(yq '.tools.just' mise.toml)/just-$(yq '.tools.just' mise.toml)-x86_64-unknown-linux-musl.tar.gz | \
+RUN uname -m
+RUN case $(uname -m) in \
+  "arm64"|"aarch64") JUST_ARCH="aarch64" ;; \
+  *) JUST_ARCH="x86_64" ;; \
+  esac && \
+  curl -L https://github.com/casey/just/releases/download/$(yq '.tools.just' mise.toml)/just-$(yq '.tools.just' mise.toml)-$JUST_ARCH-unknown-linux-musl.tar.gz | \
   tar xz -C /usr/local/bin just
 # Go sources
 COPY ./go.mod /app/go.mod
@@ -105,6 +110,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
   GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROPOSER_VERSION"
 
 FROM golang:1.24-alpine AS deployment-utils-builder
+ENV GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE
 RUN apk add gcc lld musl-dev # For CGO
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go install -ldflags '-linkmode external -extldflags "-static"' github.com/tomwright/dasel/v2/cmd/dasel@v2.8.1
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go install -ldflags '-linkmode external -extldflags "-static"' github.com/mikefarah/yq/v4@v4.47.1


### PR DESCRIPTION
After a recent MacOS upgrade to Sequoia 15.6, I discovered that many x86 binaries that were installed in the various Docker images (e.g. `yq`, `dasel`, `just`) no longer worked. Evidently something has changed regarding Apple Silicon's x86 emulation. Anyways, I modified the Dockers to download binaries of the correct architecture to match the architecture of the Docker environment.
