### PR TITLE
Remove a Caff node comment

### DIFF
--- a/.github/workflows/espresso-devnet-tests.yaml
+++ b/.github/workflows/espresso-devnet-tests.yaml
@@ -50,8 +50,8 @@ jobs:
           ./scripts/prepare-allocs.sh
           docker compose build
 
-      - name: Run Devnet tests
-        run: go test -timeout 30m -p 1 -count 1 -v  ./espresso/devnet-tests/...
+      # - name: Run Devnet tests
+      #   run: go test -timeout 30m -p 1 -count 1 -v  ./espresso/devnet-tests/...
 
       - name: Save Nix cache
         uses: nix-community/cache-nix-action/save@v6

--- a/.github/workflows/espresso-devnet-tests.yaml
+++ b/.github/workflows/espresso-devnet-tests.yaml
@@ -50,8 +50,8 @@ jobs:
           ./scripts/prepare-allocs.sh
           docker compose build
 
-      # - name: Run Devnet tests
-      #   run: go test -timeout 30m -p 1 -count 1 -v  ./espresso/devnet-tests/...
+      - name: Run Devnet tests
+        run: go test -timeout 30m -p 1 -count 1 -v  ./espresso/devnet-tests/...
 
       - name: Save Nix cache
         uses: nix-community/cache-nix-action/save@v6

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -141,7 +141,6 @@ func (aq *AttributesQueue) Origin() eth.L1BlockRef {
 //
 // This is similar to the batcher's flow: espressoBatchLoadingLoop -> getSyncStatus -> refresh -> Update -> Next,
 // but with a few key differences:
-// - CaffNextBatch obtains sync state differently from the batcher, it treated parent.Number() as the latest safe batch number.
 // - It only calls Update() when needed and everytime only calls Next() once. While the batcher calls Next() in a loop.
 // - It performs additional checks, such as validating the timestamp and parent hash, which does not apply to the batcher.
 func CaffNextBatch(s *espresso.EspressoStreamer[EspressoBatch], ctx context.Context, parent eth.L2BlockRef, blockTime uint64, l1Fetcher L1Fetcher) (*SingularBatch, bool, error) {


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211224785089945?focus=true.

### This PR:
* Removes a code comment that was about, but not really a distinction between the batcher and the Caff node.
