### PR TITLE
Fix op-batcher-tee and add op-proposer depending on it for docker compose

### DIFF
--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -412,6 +412,8 @@ services:
       - sh
       - -c
       - |
+        echo "Delaying op-batcher-tee for 45 minutes..."
+        sleep 2700
         export DEPLOYMENT_MODE=local
         export L1_RPC_URL="http://127.0.0.1:${L1_HTTP_PORT}"
         export L2_RPC_URL="http://127.0.0.1:${OP_HTTP_PORT}"
@@ -445,6 +447,34 @@ services:
       OP_PROPOSER_MNEMONIC: "test test test test test test test test test test test junk"
       OP_PROPOSER_HD_PATH: "m/44'/60'/0'/0/1"
       OP_PROPOSER_GAME_TYPE: '1'
+
+  op-proposer-tee:
+    profiles: [ "tee" ]
+    build:
+      context: ../
+      dockerfile: espresso/docker/op-stack/Dockerfile
+      target: op-proposer-target
+    image: op-proposer:espresso
+    depends_on:
+      l1-data-init:
+        condition: service_completed_successfully
+      l2-rollup:
+        condition: service_completed_successfully
+      op-node-sequencer:
+        condition: service_started
+      op-batcher-tee:
+        condition: service_started
+    volumes:
+      - ../packages/contracts-bedrock/lib/superchain-registry/ops/testdata/monorepo:/config
+      - ./deployment/deployer:/deployer
+    environment:
+      OP_PROPOSER_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
+      OP_PROPOSER_ROLLUP_RPC: http://op-node-sequencer:${ROLLUP_PORT}
+      OP_PROPOSER_PROPOSAL_INTERVAL: 6s
+      OP_PROPOSER_MNEMONIC: "test test test test test test test test test test test junk"
+      OP_PROPOSER_HD_PATH: "m/44'/60'/0'/0/1"
+      OP_PROPOSER_GAME_TYPE: '1'
+
 
   op-challenger:
     profiles: [ "default" ]

--- a/espresso/scripts/shutdown.sh
+++ b/espresso/scripts/shutdown.sh
@@ -4,3 +4,27 @@
 # This script shuts down devnet services.
 
 docker compose down -v
+
+# Stop and remove containers built from op-batcher-tee:espresso image
+echo "Stopping containers built from op-batcher-tee:espresso image..."
+CONTAINERS=$(docker ps -q --filter "ancestor=op-batcher-tee:espresso")
+if [ ! -z "$CONTAINERS" ]; then
+    echo "Stopping containers: $CONTAINERS"
+    docker stop $CONTAINERS
+    docker rm $CONTAINERS
+    echo "Containers stopped and removed"
+else
+    echo "No running containers found with op-batcher-tee:espresso image"
+fi
+
+# Stop and remove batcher-enclaver containers that run the eif
+echo "Stopping batcher-enclaver containers..."
+ENCLAVE_CONTAINERS=$(docker ps -aq --filter "name=batcher-enclaver-")
+if [ ! -z "$ENCLAVE_CONTAINERS" ]; then
+    echo "Stopping enclave containers: $ENCLAVE_CONTAINERS"
+    docker stop $ENCLAVE_CONTAINERS 2>/dev/null || true
+    docker rm $ENCLAVE_CONTAINERS 2>/dev/null || true
+    echo "Enclave containers stopped and removed"
+else
+    echo "No batcher-enclaver containers found"
+fi

--- a/espresso/scripts/startup.sh
+++ b/espresso/scripts/startup.sh
@@ -25,7 +25,7 @@ echo "✅ Contracts compilation complete"
 # Step 3: Shut down all containers
 echo "👉 Step 3: Shutting down all containers..."
 cd espresso
-docker compose down -v --remove-orphans
+./scripts/shutdown.sh
 echo "✅ All containers shut down"
 
 # Step 4: Prepare contract allocations
@@ -36,7 +36,22 @@ echo "✅ Contract allocations prepared"
 
 # Step 5: Build docker compose
 echo "👉 Step 5: Building docker compose..."
-docker compose build
+if [ "$USE_TEE" = "True" ] || [ "$USE_TEE" = "true" ]; then
+    echo "👉 Checking for AWS Nitro Enclave support..."
+    if command -v nitro-cli &>/dev/null && \
+       (nitro-cli describe-enclaves 2>/dev/null | grep -qE "EnclaveID|\[\]" || [ -e /dev/nitro_enclaves ]); then
+        echo "✅ AWS Nitro Enclave support detected"
+    else
+        echo "⚠️  WARNING: AWS Nitro Enclave support not detected! TEE components will fail."
+        read -p "Continue anyway? (y/N): " -n 1 -r
+        echo ""
+        [[ ! $REPLY =~ ^[Yy]$ ]] && { echo "❌ Startup cancelled."; exit 1; }
+    fi
+    echo "Building with TEE profile..."
+    COMPOSE_PROFILES=tee docker compose build
+else
+    docker compose build
+fi
 echo "✅ Docker compose build complete"
 
 # Step 6: Start services

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -885,7 +885,7 @@ func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBl
 
 	if newSyncStatus.CurrentL1.Number < l.prevSyncStatus.CurrentL1.Number {
 		// sequencer restarted and hasn't caught up yet
-		l.batcher.Log.Warn("sequencer currentL1 reversed", "new currentL1", newSyncStatus.CurrentL1.Number, "previous currentL1", l.prevSyncStatus.CurrentL1)
+		l.batcher.Log.Warn("sequencer currentL1 reversed", "new currentL1", newSyncStatus.CurrentL1.Number, "previous currentL1", l.prevSyncStatus.CurrentL1.Number)
 		return inclusiveBlockRange{}, ActionRetry
 	}
 


### PR DESCRIPTION
Closes
https://app.asana.com/1/1208976916964769/project/1209393353274209/task/1211412914183212?focus=true
https://app.asana.com/1/1208976916964769/project/1209393353274209/task/1211248432980276?focus=true

<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- Fix op-batcher-tee so that it starts after 45min after submitting tx to L1 is stable, and there's no more `failed to estimate gas: execution reverted, reason: 0x`
- Add another op-proposer service that depends on `op-batcher-tee`
- Fix `shutdown.sh` script so that it can correctly stop and remove op-batcher running in enclave container
- Fix `startup.sh` script so that it will check whether the user is on AWS Nitro Enclave
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

### How to test this PR: 
```
nix develop .
cd espresso/scripts

# Build and start the devnet with AWS Nitro Enclave as the TEE.
# You need to wait for 45min
USE_TEE=true ./startup.sh

# View logs.
./logs.sh <service-name>

# Stop the devnet.
./shutdown.sh
```
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
