### PR TITLE
Rename TestE2eDevNetWithEspressoSimpleTransactions

### DIFF
--- a/espresso/enclave-tests/enclave_smoke_test.go
+++ b/espresso/enclave-tests/enclave_smoke_test.go
@@ -18,9 +18,9 @@ import (
 	env "github.com/ethereum-optimism/optimism/espresso/environment"
 )
 
-// TestE2eDevNetWithEspressoSimpleTransactions launches the e2e Dev Net with the Espresso Dev Node
-// and runs a couple of simple transactions to it.
-func TestE2eDevNetWithEspressoSimpleTransactions(t *testing.T) {
+// TestE2eDevNetWithEspressoAndEnclaveSimpleTransactions launches the e2e Dev Net with the Espresso
+// Dev Node in Enclave and runs a couple of simple transactions to it.
+func TestE2eDevNetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/espresso_dev_node_test.go
+++ b/espresso/environment/espresso_dev_node_test.go
@@ -110,8 +110,8 @@ func TestE2eDevNetWithEspressoSimpleTransactions(t *testing.T) {
 
 }
 
-// TestE2eDevNetWithEspressoSimpleTransactions launches the e2e Dev Net with the Espresso Dev Node
-// and runs a couple of simple transactions to it.
+// TestE2eDevNetWithEspressoAndAltDaSimpleTransactions launches the e2e Dev Net with the Espresso
+// Dev Node in AltDA mode and runs a couple of simple transactions to it.
 func TestE2eDevNetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211480745990292?focus=true.

### This PR:
* Renames the `TestE2eDevNetWithEspressoSimpleTransactions` in `espresso/enclave-tests` to `TestE2eDevNetWithEspressoAndEnclaveSimpleTransactions` to distinguish it from the test with the same name in `espresso/environment`.
* Update the description of `TestE2eDevNetWithEspressoAndAltDaSimpleTransactions`.
