### PR TITLE
Fix `TestSmoke` failing on `CI/CD`

### DIFF
--- a/.github/workflows/espresso-devnet-tests.yaml
+++ b/.github/workflows/espresso-devnet-tests.yaml
@@ -13,13 +13,13 @@ jobs:
   test:
     runs-on: ubuntu-24.04-8core
     env:
-        ESPRESSO_DEVNET_TESTS_LIVENESS_PERIOD: '1m'
-        ESPRESSO_DEVNET_TESTS_OUTAGE_PERIOD: '1m'
+      ESPRESSO_DEVNET_TESTS_LIVENESS_PERIOD: "1m"
+      ESPRESSO_DEVNET_TESTS_OUTAGE_PERIOD: "1m"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v30
@@ -49,6 +49,7 @@ jobs:
           cd ../espresso
           ./scripts/prepare-allocs.sh
           docker compose build
+          docker compose pull l1-validator espresso-dev-node l1-data-init
 
       - name: Run Smoke test
         run: go test -timeout 30m -p 1 -count 1 -run 'TestSmoke' -v  ./espresso/devnet-tests/...

--- a/espresso/devnet-tests/devnet_tools.go
+++ b/espresso/devnet-tests/devnet_tools.go
@@ -80,7 +80,31 @@ func NewDevnet(ctx context.Context, t *testing.T) *Devnet {
 	return d
 }
 
+func (d *Devnet) isRunning() bool {
+	cmd := exec.CommandContext(
+		d.ctx,
+		"docker", "compose", "ps", "-q",
+	)
+	buf := new(bytes.Buffer)
+	cmd.Stdout = buf
+	if err := cmd.Run(); err != nil {
+		log.Error("failed to check if devnet is running", "error", err)
+		return false
+	}
+	out := strings.TrimSpace(buf.String())
+	return len(out) > 0
+}
+
 func (d *Devnet) Up() (err error) {
+	if d.isRunning() {
+		if err := d.Down(); err != nil {
+			return err
+		}
+		// Let's shutdown the devnet before returning an error, just to clean
+		// up any existing state.
+		return fmt.Errorf("devnet is already running, this should be a clean state; please shut it down first")
+	}
+
 	cmd := exec.CommandContext(
 		d.ctx,
 		"docker", "compose", "up", "-d",

--- a/espresso/devnet-tests/smoke_test.go
+++ b/espresso/devnet-tests/smoke_test.go
@@ -3,12 +3,13 @@ package devnet_tests
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestSmoke(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
 	d := NewDevnet(ctx, t)

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - l1-data:/data
 
   l1-validator:
-    image: sigp/lighthouse
+    image: sigp/lighthouse:v7.1.0
     depends_on:
       l1-genesis:
         condition: service_completed_successfully
@@ -56,7 +56,7 @@ services:
       - ${OPERATOR_ADDRESS}
 
   l1-beacon:
-    image: sigp/lighthouse
+    image: sigp/lighthouse:v7.1.0
     depends_on:
       l1-genesis:
         condition: service_completed_successfully


### PR DESCRIPTION
<!-- Closes #<ISSUE_NUMBER> -->
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Fixes the failing DevNet tests in CI/CD.

The CI/CD tests have been failing due to the `docker compose up -d` task not resolving within the allotted test time.  Upon investigating this issue it was noticed that the `TestSmoke` test was failing due, in part to docker images being pulled while the test was running.  To rectify this, a `docker build pull` command was added to the `Build Devnet` `CI/CD` job.

Another issue that was noticed that the devnet stopped launching locally from a clean install.  This was pinpointed to be due to the `l2-genesis` task not completing.  Looking at the logs for this indicated that it never receives a finalized block.  Using this information, the `l1-geth` was inspected to find that indeed it was not producing any `finalized` blocks.   Yet, even more alarming it was not producing **ANY** blocks at all.  From here attention turned to the `l1-beacon`.

The `l1-beacon` and `l1-validator` containers both utilize the docker image `sigp/lighouse` withou a tag specified.  This means it will use the `latest` tag by default.  It just so happens that on `2025-09-29` a new `latest` tag was released for `sigp/lighouse` taking the version from `v7.1.0` to `v8.0.0-rc.0`.  There seems to be breaking changes with this version that prevents it from working against our current setup.  To address this issue tag `v7.1.0` was added to the `sigp/lighouse` images in the `docker-compose.yml`.

<!-- ### This PR does not: -->
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211525502259727