### PR TITLE
Rename DevNet to E2eDevnet

### DIFF
--- a/espresso/enclave-tests/enclave_smoke_test.go
+++ b/espresso/enclave-tests/enclave_smoke_test.go
@@ -18,9 +18,9 @@ import (
 	env "github.com/ethereum-optimism/optimism/espresso/environment"
 )
 
-// TestE2eDevNetWithEspressoAndEnclaveSimpleTransactions launches the e2e Dev Net with the Espresso
+// TestE2eDevnetWithEspressoAndEnclaveSimpleTransactions launches the e2e Dev Net with the Espresso
 // Dev Node in Enclave and runs a couple of simple transactions to it.
-func TestE2eDevNetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
+func TestE2eDevnetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -29,7 +29,7 @@ func TestE2eDevNetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 	launcher.EnclaveBatcher = true
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}

--- a/espresso/environment/10_soft_confirmation_integrity_test.go
+++ b/espresso/environment/10_soft_confirmation_integrity_test.go
@@ -522,7 +522,7 @@ func TestSequencerFeedConsistency(t *testing.T) {
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(0))
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(0))
 
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
@@ -584,7 +584,7 @@ func TestSequencerFeedConsistencyWithAttackOnEspresso(t *testing.T) {
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(0))
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(0))
 
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {

--- a/espresso/environment/11_forced_transaction_test.go
+++ b/espresso/environment/11_forced_transaction_test.go
@@ -61,7 +61,7 @@ func ForcedTransaction(t *testing.T, withSmallSequencerWindow bool, withEspresso
 	var err error
 	if withEspresso {
 		launcher := new(env.EspressoDevNodeLauncherDocker)
-		systemWithEspresso, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithSequencerWindowSize(sequencer_window_size(withSmallSequencerWindow)))
+		systemWithEspresso, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithSequencerWindowSize(sequencer_window_size(withSmallSequencerWindow)))
 		system = systemWithEspresso
 		require.NoError(t, err, "Failed to launch with the Espresso dev node")
 		defer env.Stop(t, system)

--- a/espresso/environment/12_enforce_majority_rule_test.go
+++ b/espresso/environment/12_enforce_majority_rule_test.go
@@ -36,7 +36,7 @@ func runWithMultiClient(t *testing.T, numGoodUrls int, numBadUrls int, expectedE
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, devNode, err := launcher.StartDevNet(ctx, t, env.SetEspressoUrls(numGoodUrls, numBadUrls, badServerUrl))
+	system, devNode, err := launcher.StartE2eDevnet(ctx, t, env.SetEspressoUrls(numGoodUrls, numBadUrls, badServerUrl))
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}

--- a/espresso/environment/13_dispute_game_test.go
+++ b/espresso/environment/13_dispute_game_test.go
@@ -36,7 +36,7 @@ func TestOutputAlphabetGameWithEspresso_ChallengerWins(t *testing.T) {
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
 	// Start a Fault Dispute System with Espresso Dev Node
-	sys, espressoDevNode, err := launcher.StartDevNetWithFaultDisputeSystem(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
+	sys, espressoDevNode, err := launcher.StartE2eDevnetWithFaultDisputeSystem(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
 
 	l1Client := sys.NodeClient("l1")
 

--- a/espresso/environment/1_espresso_benchmark_test.go
+++ b/espresso/environment/1_espresso_benchmark_test.go
@@ -12,7 +12,7 @@ import (
 	geth_types "github.com/ethereum/go-ethereum/core/types"
 )
 
-// TestE2eDevNetWithEspressoFastConfirmationStability is a test that tests
+// TestE2eDevnetWithEspressoFastConfirmationStability is a test that tests
 // the benchmarking setup of the Espresso Caff Node's performance versus the
 // L2 Verifier derived from the L1.
 //
@@ -44,12 +44,12 @@ import (
 //
 // For the purposes of this test the "reasonable" value is defined to
 // be 2 seconds.
-func TestE2eDevNetWithEspressoFastConfirmationStability(t *testing.T) {
+func TestE2eDevnetWithEspressoFastConfirmationStability(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
-	system, espressoDevNode, err := launcher.StartDevNet(
+	system, espressoDevNode, err := launcher.StartE2eDevnet(
 		ctx,
 		t,
 		env.WithSequencerUseFinalized(true),

--- a/espresso/environment/2_espresso_liveness_test.go
+++ b/espresso/environment/2_espresso_liveness_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestE2eDevnetWithEspressoEspressoDegradedLiveness is a test that checks that
+// TestE2eDevnetWithEspressoDegradedLiveness is a test that checks that
 // the rollup will continue to make progress even in the event of intermittent
 // Espresso system failures.
 //
@@ -57,7 +57,7 @@ import (
 // Likewise, we might be able to simulate 3 by falsely reporting to the
 // submitter that the transaction was submitted successfully, and withholding
 // the submission itself.
-func TestE2eDevnetWithEspressoEspressoDegradedLiveness(t *testing.T) {
+func TestE2eDevnetWithEspressoDegradedLiveness(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -139,7 +139,7 @@ func TestE2eDevnetWithEspressoEspressoDegradedLiveness(t *testing.T) {
 	}
 }
 
-// TestE2eDevnetWithEspressoEspressoDegradedLivenessViaCaffNode is a test that
+// TestE2eDevnetWithEspressoDegradedLivenessViaCaffNode is a test that
 // checks that Espresso will return fast confirmations even when in a
 // degraded state.
 //
@@ -165,7 +165,7 @@ func TestE2eDevnetWithEspressoEspressoDegradedLiveness(t *testing.T) {
 // a Transaction, we should be able to find the receipt on the L2, and then
 // we can use that Block information to track the arrival of the Transaction
 // / Block coming from Espresso.
-func TestE2eDevnetWithEspressoEspressoDegradedLivenessViaCaffNode(t *testing.T) {
+func TestE2eDevnetWithEspressoDegradedLivenessViaCaffNode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/espresso/environment/2_espresso_liveness_test.go
+++ b/espresso/environment/2_espresso_liveness_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestE2eDevNetWithEspressoEspressoDegradedLiveness is a test that checks that
+// TestE2eDevnetWithEspressoEspressoDegradedLiveness is a test that checks that
 // the rollup will continue to make progress even in the event of intermittent
 // Espresso system failures.
 //
@@ -57,7 +57,7 @@ import (
 // Likewise, we might be able to simulate 3 by falsely reporting to the
 // submitter that the transaction was submitted successfully, and withholding
 // the submission itself.
-func TestE2eDevNetWithEspressoEspressoDegradedLiveness(t *testing.T) {
+func TestE2eDevnetWithEspressoEspressoDegradedLiveness(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -79,7 +79,7 @@ func TestE2eDevNetWithEspressoEspressoDegradedLiveness(t *testing.T) {
 	)
 
 	defer server.Close()
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, option)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, option)
 
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
@@ -139,7 +139,7 @@ func TestE2eDevNetWithEspressoEspressoDegradedLiveness(t *testing.T) {
 	}
 }
 
-// TestE2eDevNetWithEspressoEspressoDegradedLivenessViaCaffNode is a test that
+// TestE2eDevnetWithEspressoEspressoDegradedLivenessViaCaffNode is a test that
 // checks that Espresso will return fast confirmations even when in a
 // degraded state.
 //
@@ -165,7 +165,7 @@ func TestE2eDevNetWithEspressoEspressoDegradedLiveness(t *testing.T) {
 // a Transaction, we should be able to find the receipt on the L2, and then
 // we can use that Block information to track the arrival of the Transaction
 // / Block coming from Espresso.
-func TestE2eDevNetWithEspressoEspressoDegradedLivenessViaCaffNode(t *testing.T) {
+func TestE2eDevnetWithEspressoEspressoDegradedLivenessViaCaffNode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -185,7 +185,7 @@ func TestE2eDevNetWithEspressoEspressoDegradedLivenessViaCaffNode(t *testing.T) 
 	)
 
 	defer env.Stop(t, server)
-	system, espressoDevNode, err := launcher.StartDevNet(
+	system, espressoDevNode, err := launcher.StartE2eDevnet(
 		ctx,
 		t,
 		option,

--- a/espresso/environment/3_1_espresso_caff_node_test.go
+++ b/espresso/environment/3_1_espresso_caff_node_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
-// TestE2eDevNetWithEspressoWithCaffNodeDeterministicDerivation is a test that
+// TestE2eDevnetWithEspressoWithCaffNodeDeterministicDerivation is a test that
 // attempts to make sure that the caff node can derive the same state as the
 // original op-node (non caffeinated).
 //
@@ -31,13 +31,13 @@ import (
 //
 // The actual tests is unable to make Alice's initial balance zero, and will
 // instead just check Alice's starting balance against the rest of the cases.
-func TestE2eDevNetWithEspressoWithCaffNodeDeterministicDerivation(t *testing.T) {
+func TestE2eDevnetWithEspressoWithCaffNodeDeterministicDerivation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/3_2_espresso_deterministic_state_test.go
+++ b/espresso/environment/3_2_espresso_deterministic_state_test.go
@@ -50,7 +50,7 @@ func TestDeterministicDerivationExecutionStateWithInvalidTransaction(t *testing.
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
 	// Start the devnet with the sequencer using finalized blocks
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
@@ -264,8 +264,8 @@ func TestValidEspressoTransactionCreation(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	// once this StartDevNet returns, we have a running Espresso Dev Node
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	// once this StartE2eDevnet returns, we have a running Espresso Dev Node
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/3_3_fast_derivation_and_caff_node_test.go
+++ b/espresso/environment/3_3_fast_derivation_and_caff_node_test.go
@@ -56,7 +56,7 @@ func TestFastDerivationAndCaffNode(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
 
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {

--- a/espresso/environment/4_confirmation_integrity_with_reorgs_test.go
+++ b/espresso/environment/4_confirmation_integrity_with_reorgs_test.go
@@ -205,7 +205,7 @@ func TestConfirmationIntegrityWithReorgs(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, _, err := launcher.StartDevNet(ctx, t)
+	system, _, err := launcher.StartE2eDevnet(ctx, t)
 	require.NoError(t, err, "failed to start dev environment with espresso dev node")
 
 	run(ctx, t, system)

--- a/espresso/environment/5_batch_authentication_test.go
+++ b/espresso/environment/5_batch_authentication_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/hf/nitrite"
 )
 
-// TestE2eDevNetWithInvalidAttestation verifies that the batcher correctly fails to register
+// TestE2eDevnetWithInvalidAttestation verifies that the batcher correctly fails to register
 // when provided with an invalid attestation. This test ensures that the batch inbox contract
 // properly validates attestations
-func TestE2eDevNetWithInvalidAttestation(t *testing.T) {
+func TestE2eDevnetWithInvalidAttestation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -29,7 +29,7 @@ func TestE2eDevNetWithInvalidAttestation(t *testing.T) {
 	}
 
 	system, _, err :=
-		launcher.StartDevNet(ctx, t,
+		launcher.StartE2eDevnet(ctx, t,
 			env.SetBatcherKey(*privateKey),
 			env.Config(func(cfg *e2esys.SystemConfig) {
 				cfg.DisableBatcher = true
@@ -60,9 +60,9 @@ func TestE2eDevNetWithInvalidAttestation(t *testing.T) {
 	}
 }
 
-// TestE2eDevNetWithUnattestedBatcherKey verifies that when a batcher key is not properly
+// TestE2eDevnetWithUnattestedBatcherKey verifies that when a batcher key is not properly
 // attested, the L2 chain can still produce unsafe blocks but cannot progress to safe L2 blocks.
-func TestE2eDevNetWithUnattestedBatcherKey(t *testing.T) {
+func TestE2eDevnetWithUnattestedBatcherKey(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -74,7 +74,7 @@ func TestE2eDevNetWithUnattestedBatcherKey(t *testing.T) {
 	}
 
 	system, _, err :=
-		launcher.StartDevNet(ctx, t,
+		launcher.StartE2eDevnet(ctx, t,
 			env.SetBatcherKey(*privateKey),
 		)
 	if have, want := err, error(nil); have != want {

--- a/espresso/environment/6_batch_inbox_test.go
+++ b/espresso/environment/6_batch_inbox_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestE2eDevNetWithoutAuthenticatingBatches verifies BatchInboxContract behaviour when batches
+// TestE2eDevnetWithoutAuthenticatingBatches verifies BatchInboxContract behaviour when batches
 // aren't attested before being posted to batch inbox. To do this, we substitute BatchAuthenticatorAddress
 // in batcher config with a zero address, which will never revert as it has no contract deployed.
 // This way we trick batcher into posting unauthenticated batches to batch inbox.
@@ -37,14 +37,14 @@ import (
 //	Assert that transaction submitting the batch was reverted by
 //	batch inbox contract
 //	Assert that derivation pipeline doesn't progress
-func TestE2eDevNetWithoutAuthenticatingBatches(t *testing.T) {
+func TestE2eDevnetWithoutAuthenticatingBatches(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
 	system, _, err :=
-		launcher.StartDevNet(ctx, t,
+		launcher.StartE2eDevnet(ctx, t,
 			env.Config(func(cfg *e2esys.SystemConfig) {
 				cfg.DisableBatcher = true
 			}),

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -41,7 +41,7 @@ func TestStatelessBatcher(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/8_reorg_test.go
+++ b/espresso/environment/8_reorg_test.go
@@ -38,7 +38,7 @@ func TestBatcherWaitForFinality(t *testing.T) {
 
 	// Set NonFinalizedProposals to true and SequencerUseFinalized to false, to make sure we are
 	// testing how the batcher handles the finality.
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(4), env.WithNonFinalizedProposals(true), env.WithSequencerUseFinalized(false))
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(4), env.WithNonFinalizedProposals(true), env.WithSequencerUseFinalized(false))
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -139,7 +139,7 @@ func TestCaffNodeWaitForFinality(t *testing.T) {
 
 	// Set L1FinalizedDistance to nonzero, NonFinalizedProposals to true, and SequencerUseFinalized
 	// to false, to make sure we are testing how the Caff node handles the finality.
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(4), env.WithNonFinalizedProposals(true), env.WithSequencerUseFinalized(false))
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(4), env.WithNonFinalizedProposals(true), env.WithSequencerUseFinalized(false))
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -244,7 +244,7 @@ func runL1Reorg(ctx context.Context, t *testing.T, system *e2esys.System) {
 	require.Equal(t, caffL2Head.Hash(), newL2Head.Hash())
 }
 
-// TestE2eDevNetWithL1Reorg tests how the batcher and Caff node handle an L1 reorg.
+// TestE2eDevnetWithL1Reorg tests how the batcher and Caff node handle an L1 reorg.
 // Specifically, it focuses on cases where unsafe L2 chain contains blocks that
 // reference unfinalized L1 blocks as their origin.
 //
@@ -263,13 +263,13 @@ func runL1Reorg(ctx context.Context, t *testing.T, system *e2esys.System) {
 //
 //	Assert that derivation pipeline still progresses
 //	Assert that Caff and OP node report a new block at the target L2 height
-func TestE2eDevNetWithL1Reorg(t *testing.T) {
+func TestE2eDevnetWithL1Reorg(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, devNode, err := launcher.StartDevNet(ctx, t, env.WithL1FinalizedDistance(16))
+	system, devNode, err := launcher.StartE2eDevnet(ctx, t, env.WithL1FinalizedDistance(16))
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}

--- a/espresso/environment/9_pipeline_enhancement_test.go
+++ b/espresso/environment/9_pipeline_enhancement_test.go
@@ -40,7 +40,7 @@ func TestPipelineEnhancement(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	require.NoError(t, err, "failed to start dev environment with espresso dev node")
 
 	// Stop the batcher to ensure no valid batch is posted to L1.

--- a/espresso/environment/e2e_helpers.go
+++ b/espresso/environment/e2e_helpers.go
@@ -53,10 +53,10 @@ func L2TxWithOptions(options ...helpers.TxOptsFn) helpers.TxOptsFn {
 	}
 }
 
-// WithSequencerUseFinalized is a DevNetLauncherOption that configures the sequencer's
+// WithSequencerUseFinalized is a E2eDevnetLauncherOption that configures the sequencer's
 // `SequencerUseFinalized` option to the provided value.
-func WithSequencerUseFinalized(useFinalized bool) DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func WithSequencerUseFinalized(useFinalized bool) E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				seqConfig := cfg.Nodes[e2esys.RoleSeq]
@@ -66,10 +66,10 @@ func WithSequencerUseFinalized(useFinalized bool) DevNetLauncherOption {
 	}
 }
 
-// WithNonFinalizedProposals is a DevNetLauncherOption that configures the system's
+// WithNonFinalizedProposals is a E2eDevnetLauncherOption that configures the system's
 // `NonFinalizedProposals` option to the provided value.
-func WithNonFinalizedProposals(useNonFinalized bool) DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func WithNonFinalizedProposals(useNonFinalized bool) E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.NonFinalizedProposals = useNonFinalized
@@ -78,10 +78,10 @@ func WithNonFinalizedProposals(useNonFinalized bool) DevNetLauncherOption {
 	}
 }
 
-// WithL1FinalizedDistance is a DevNetLauncherOption that configures the system's
+// WithL1FinalizedDistance is a E2eDevnetLauncherOption that configures the system's
 // `L1FinalizedDistance` option to the provided value.
-func WithL1FinalizedDistance(distance uint64) DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func WithL1FinalizedDistance(distance uint64) E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.L1FinalizedDistance = distance
@@ -90,10 +90,10 @@ func WithL1FinalizedDistance(distance uint64) DevNetLauncherOption {
 	}
 }
 
-// WithSeqWindowSize is a DevNetLauncherOption that configures the deployment's
+// WithSeqWindowSize is a E2eDevnetLauncherOption that configures the deployment's
 // `SequencerWindowSize` option to the provided value.
-func WithSequencerWindowSize(size uint64) DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func WithSequencerWindowSize(size uint64) E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DeployConfig.SequencerWindowSize = size
@@ -102,13 +102,13 @@ func WithSequencerWindowSize(size uint64) DevNetLauncherOption {
 	}
 }
 
-// WithL1BlockTime is a DevNetLauncherOption that configures the system's
+// WithL1BlockTime is a E2eDevnetLauncherOption that configures the system's
 // `L1BlockTime` option to the provided value.
 //
 // The passed block time should be on the order of seconds.  Any sub-second
 // resolution will be lost.  The value **MUST** be at least 1 second or greater.
-func WithL1BlockTime(blockTime time.Duration) DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func WithL1BlockTime(blockTime time.Duration) E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DeployConfig.L1BlockTime = uint64(blockTime / time.Second)
@@ -117,13 +117,13 @@ func WithL1BlockTime(blockTime time.Duration) DevNetLauncherOption {
 	}
 }
 
-// WithL2BlockTime is a DevNetLauncherOption that configures the system's
+// WithL2BlockTime is a E2eDevnetLauncherOption that configures the system's
 // `L2BlockTime` option to the provided value.
 //
 // The passed block time should be on the order of seconds.  Any sub-second
 // resolution will be lost.  The value **MUST** be at least 1 second or greater.
-func WithL2BlockTime(blockTime time.Duration) DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func WithL2BlockTime(blockTime time.Duration) E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DeployConfig.L2BlockTime = uint64(blockTime / time.Second)

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -70,8 +70,8 @@ func appendArg(args *[]string, flagName string, value any) {
 	}
 }
 
-func LaunchBatcherInEnclave() DevNetLauncherOption {
-	return func(ct *DevNetLauncherContext) E2eSystemOption {
+func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
+	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DisableBatcher = true

--- a/espresso/environment/espresso_dev_net_launcher.go
+++ b/espresso/environment/espresso_dev_net_launcher.go
@@ -8,20 +8,18 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 )
 
-// EspressoDevNetLauncher is an interface for launching a Dev Net with Espresso,
-// and configuring it to run in a desired manner.
-type EspressoDevNetLauncher interface {
+// EspressoE2eDevnetLauncher is an interface for launching an E2E devnet with Espresso, and
+// configuring it to run in a desired manner.
+type EspressoE2eDevnetLauncher interface {
 
-	// StartDevNet will launch the DevNet with the provided options. The
-	// returned system will be a fully configured e2e system with the configured
-	// options.
-	StartDevNet(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error)
+	// StartE2eDevnet will launch the devnet with the provided options. The returned system will be
+	// a fully configured e2e system with the configured options.
+	StartE2eDevnet(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error)
 }
 
-// DevNetLauncherContext is a struct that contains the context and any errors
-// that may have occurred during the launch of the DevNet. It also contains
-// the current system instance.
-type DevNetLauncherContext struct {
+// E2eDevnetLauncherContext is a struct that contains the context and any errors that may have
+// occurred during the launch of the E2E devnet. It also contains the current system instance.
+type E2eDevnetLauncherContext struct {
 	// The launching Context
 	Ctx context.Context
 
@@ -38,10 +36,10 @@ type DevNetLauncherContext struct {
 	EspressoDevNode
 }
 
-// DevNetLauncherOption is a function that takes a DevNetLauncherContext
+// E2eDevnetLauncherOption is a function that takes a E2eDevnetLauncherContext
 // and returns an E2eSystemOption.
-type DevNetLauncherOption func(
-	ctx *DevNetLauncherContext,
+type E2eDevnetLauncherOption func(
+	ctx *E2eDevnetLauncherContext,
 ) E2eSystemOption
 
 // E2eSystemOption is a struct that contains the options for the

--- a/espresso/environment/espresso_dev_node_test.go
+++ b/espresso/environment/espresso_dev_node_test.go
@@ -19,7 +19,7 @@ func TestEspressoDockerDevNodeSmokeTest(t *testing.T) {
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -86,15 +86,15 @@ func TestEspressoDockerDevNodeSmokeTest(t *testing.T) {
 	}
 }
 
-// TestE2eDevNetWithEspressoSimpleTransactions launches the e2e Dev Net with the Espresso Dev Node
+// TestE2eDevnetWithEspressoSimpleTransactions launches the e2e Dev Net with the Espresso Dev Node
 // and runs a couple of simple transactions to it.
-func TestE2eDevNetWithEspressoSimpleTransactions(t *testing.T) {
+func TestE2eDevnetWithEspressoSimpleTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -110,16 +110,16 @@ func TestE2eDevNetWithEspressoSimpleTransactions(t *testing.T) {
 
 }
 
-// TestE2eDevNetWithEspressoAndAltDaSimpleTransactions launches the e2e Dev Net with the Espresso
+// TestE2eDevnetWithEspressoAndAltDaSimpleTransactions launches the e2e Dev Net with the Espresso
 // Dev Node in AltDA mode and runs a couple of simple transactions to it.
-func TestE2eDevNetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
+func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 	launcher.AltDa = true
 
-	system, espressoDevNode, err := launcher.StartDevNet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -135,9 +135,9 @@ func TestE2eDevNetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 
 }
 
-// TestE2eDevNetWithoutEspressoSimpleTransactions launches the e2e Dev Net
+// TestE2eDevnetWithoutEspressoSimpleTransactions launches the e2e Dev Net
 // without the Espresso Dev Node and runs a couple of simple transactions to it.
-func TestE2eDevNetWithoutEspressoSimpleTransaction(t *testing.T) {
+func TestE2eDevnetWithoutEspressoSimpleTransaction(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -146,7 +146,7 @@ type EspressoDevNodeLauncherDocker struct {
 	AltDa bool
 }
 
-var _ EspressoDevNetLauncher = (*EspressoDevNodeLauncherDocker)(nil)
+var _ EspressoE2eDevnetLauncher = (*EspressoDevNodeLauncherDocker)(nil)
 
 // FailedToDetermineL1RPCURL represents a class of errors that occur when we
 // are unable to correctly form our L1 RPC URL
@@ -249,8 +249,8 @@ func (e EspressoDevNodeContainerInfo) Stop() error {
 // is meant to be.
 var ErrUnableToDetermineEspressoDevNodeSequencerHost = errors.New("unable to determine the host for the espresso-dev-node sequencer api")
 
-// GetDevNetConfig returns a configuration for a devnet
-func (l *EspressoDevNodeLauncherDocker) GetDevNetSysConfig(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) e2esys.SystemConfig {
+// GetE2eDevnetSysConfig returns a configuration for an E2E devnet.
+func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetSysConfig(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) e2esys.SystemConfig {
 
 	var allocOpt e2esys.SystemConfigOpt
 	if l.EnclaveBatcher {
@@ -295,8 +295,9 @@ func (l *EspressoDevNodeLauncherDocker) GetDevNetSysConfig(ctx context.Context, 
 	return sysConfig
 }
 
-// GetDevNetWithFaultDisputeSysConfig returns a configuration for a devnet with a Fault Dispute System
-func (l *EspressoDevNodeLauncherDocker) GetDevNetWithFaultDisputeSysConfig(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) e2esys.SystemConfig {
+// GetE2eDevnetWithFaultDisputeSysConfig returns a configuration for an E2E devnet with a Fault
+// Dispute System.
+func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetWithFaultDisputeSysConfig(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) e2esys.SystemConfig {
 	var allocOpt e2esys.SystemConfigOpt
 	if l.EnclaveBatcher {
 		allocOpt = e2esys.WithAllocType(config.AllocTypeEspressoWithEnclave)
@@ -341,9 +342,9 @@ func (l *EspressoDevNodeLauncherDocker) GetDevNetWithFaultDisputeSysConfig(ctx c
 	return sysConfig
 }
 
-// GetDevNetStartOptions returns the start options for the devnet
-func (l *EspressoDevNodeLauncherDocker) GetDevNetStartOptions(originalCtx context.Context, t *testing.T, sysConfig *e2esys.SystemConfig, options ...DevNetLauncherOption) ([]e2esys.StartOption, *DevNetLauncherContext) {
-	initialOptions := []DevNetLauncherOption{
+// GetE2eDevnetStartOptions returns the start options for the E2E devnet.
+func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetStartOptions(originalCtx context.Context, t *testing.T, sysConfig *e2esys.SystemConfig, options ...E2eDevnetLauncherOption) ([]e2esys.StartOption, *E2eDevnetLauncherContext) {
+	initialOptions := []E2eDevnetLauncherOption{
 		allowHostDockerInternalVirtualHost(),
 		launchEspressoDevNodeDocker(),
 	}
@@ -352,7 +353,7 @@ func (l *EspressoDevNodeLauncherDocker) GetDevNetStartOptions(originalCtx contex
 		initialOptions = append(initialOptions, LaunchBatcherInEnclave())
 	}
 
-	launchContext := DevNetLauncherContext{
+	launchContext := E2eDevnetLauncherContext{
 		Ctx:       originalCtx,
 		SystemCfg: sysConfig,
 	}
@@ -382,12 +383,12 @@ func (l *EspressoDevNodeLauncherDocker) GetDevNetStartOptions(originalCtx contex
 	return startOptions, &launchContext
 }
 
-func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
+func (l *EspressoDevNodeLauncherDocker) StartE2eDevnet(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
 
-	sysConfig := l.GetDevNetSysConfig(ctx, t, options...)
+	sysConfig := l.GetE2eDevnetSysConfig(ctx, t, options...)
 
 	originalCtx := ctx
-	startOptions, launchContext := l.GetDevNetStartOptions(originalCtx, t, &sysConfig, options...)
+	startOptions, launchContext := l.GetE2eDevnetStartOptions(originalCtx, t, &sysConfig, options...)
 
 	// We want to run the espresso-dev-node.  But we need it to be able to
 	// access the L1 node.
@@ -425,13 +426,13 @@ func (l *EspressoDevNodeLauncherDocker) StartDevNet(ctx context.Context, t *test
 	return system, launchContext.EspressoDevNode, launchContext.Error
 }
 
-// StartDevNetWithFaultDisputeSystem starts a Fault Dispute System with an Espresso Dev Node
-func (l *EspressoDevNodeLauncherDocker) StartDevNetWithFaultDisputeSystem(ctx context.Context, t *testing.T, options ...DevNetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
+// StartE2eDevnetWithFaultDisputeSystem starts a Fault Dispute System with an Espresso Dev Node
+func (l *EspressoDevNodeLauncherDocker) StartE2eDevnetWithFaultDisputeSystem(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
 
-	sysConfig := l.GetDevNetWithFaultDisputeSysConfig(ctx, t, options...)
+	sysConfig := l.GetE2eDevnetWithFaultDisputeSysConfig(ctx, t, options...)
 
 	originalCtx := ctx
-	startOptions, launchContext := l.GetDevNetStartOptions(originalCtx, t, &sysConfig, options...)
+	startOptions, launchContext := l.GetE2eDevnetStartOptions(originalCtx, t, &sysConfig, options...)
 
 	system, err := sysConfig.Start(
 		t,
@@ -513,8 +514,8 @@ func (e EspressoDevNodeDockerContainerInfo) Stop() error {
 //
 // host.docker.internal is a special DNS name that allows docker containers
 // to speak to ports hosted on the host node.
-func allowHostDockerInternalVirtualHost() DevNetLauncherOption {
-	return func(c *DevNetLauncherContext) E2eSystemOption {
+func allowHostDockerInternalVirtualHost() E2eDevnetLauncherOption {
+	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			GethOptions: map[string][]geth.GethOption{
 				e2esys.RoleL1: {
@@ -547,8 +548,8 @@ func determineFreePort() (port int, err error) {
 	return addr.Port, nil
 }
 
-func SetBatcherKey(privateKey ecdsa.PrivateKey) DevNetLauncherOption {
-	return func(ct *DevNetLauncherContext) E2eSystemOption {
+func SetBatcherKey(privateKey ecdsa.PrivateKey) E2eDevnetLauncherOption {
+	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			StartOptions: []e2esys.StartOption{
 				{
@@ -565,8 +566,8 @@ func SetBatcherKey(privateKey ecdsa.PrivateKey) DevNetLauncherOption {
 // SetEspressoUrls allows to set the list of urls for the Espresso client in such a way that N of them are "good" and M of them are "bad".
 // Good urls are the urls defined by this test framework repeated M times. The bad url is provided to the function
 // This function is introduced for testing purposes. It allows to check the enforcement of the majority rule (Test 12)
-func SetEspressoUrls(numGood int, numBad int, badServerUrl string) DevNetLauncherOption {
-	return func(ct *DevNetLauncherContext) E2eSystemOption {
+func SetEspressoUrls(numGood int, numBad int, badServerUrl string) E2eDevnetLauncherOption {
+	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 
 		return E2eSystemOption{
 			StartOptions: []e2esys.StartOption{
@@ -591,8 +592,8 @@ func SetEspressoUrls(numGood int, numBad int, badServerUrl string) DevNetLaunche
 	}
 }
 
-func Config(fn func(*e2esys.SystemConfig)) DevNetLauncherOption {
-	return func(ct *DevNetLauncherContext) E2eSystemOption {
+func Config(fn func(*e2esys.SystemConfig)) E2eDevnetLauncherOption {
+	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			SysConfigOption: fn,
 		}
@@ -625,7 +626,7 @@ func getContainerRemappedHostPort(containerListeningHostPort string) (string, er
 // It checks the portMap of the DockerContainerInfo to retrieve the
 // Espresso Dev Node Sequencer API port, and then waits for the block height
 // to be greater than 0.
-func waitForEspressoToFinishSpinningUp(ct *DevNetLauncherContext, espressoDevNodeContainerInfo DockerContainerInfo) error {
+func waitForEspressoToFinishSpinningUp(ct *E2eDevnetLauncherContext, espressoDevNodeContainerInfo DockerContainerInfo) error {
 	// We have all of our ports.
 	// Let's return all of the relevant port mapping information
 	// for easy reference, and cancellation
@@ -801,10 +802,10 @@ func ensureHardCodedPortsAreMappedFromTheirOriginalValues(containerInfo *DockerC
 	}
 }
 
-// launchEspressoDevNodeDocker is DevNetLauncherOption that launches th
+// launchEspressoDevNodeDocker is E2eDevnetLauncherOption that launches th
 // Espresso Dev Node within a Docker container.  It also ensures that the
 // Espresso Dev Node is actively producing blocks before returning.
-func launchEspressoDevNodeStartOption(ct *DevNetLauncherContext) e2esys.StartOption {
+func launchEspressoDevNodeStartOption(ct *E2eDevnetLauncherContext) e2esys.StartOption {
 	return e2esys.StartOption{
 		Role: "launch-espresso-dev-node",
 		BatcherMod: func(c *batcher.CLIConfig, sys *e2esys.System) {
@@ -872,11 +873,11 @@ func launchEspressoDevNodeStartOption(ct *DevNetLauncherContext) e2esys.StartOpt
 
 }
 
-// launchEspressoDevNodeDocker is DevNetLauncherOption that launches th
+// launchEspressoDevNodeDocker is E2eDevnetLauncherOption that launches th
 // Espresso Dev Node within a Docker container.  It also ensures that the
 // Espresso Dev Node is actively producing blocks before returning.
-func launchEspressoDevNodeDocker() DevNetLauncherOption {
-	return func(ct *DevNetLauncherContext) E2eSystemOption {
+func launchEspressoDevNodeDocker() E2eDevnetLauncherOption {
+	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			StartOptions: []e2esys.StartOption{
 				launchEspressoDevNodeStartOption(ct),

--- a/espresso/environment/query_service_intercept.go
+++ b/espresso/environment/query_service_intercept.go
@@ -330,7 +330,7 @@ func (e *EspressoDevNodeIntercept) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 // createEspressoProxyOption will return a Batch CLIConfig option that will
 // replace the Espresso URL with the URL of the proxy server.
-func createEspressoProxyOption(ctx *DevNetLauncherContext, proxy *EspressoDevNodeIntercept, server *httptest.Server) func(*batcher.CLIConfig, *e2esys.System) {
+func createEspressoProxyOption(ctx *E2eDevnetLauncherContext, proxy *EspressoDevNodeIntercept, server *httptest.Server) func(*batcher.CLIConfig, *e2esys.System) {
 	return func(cfg *batcher.CLIConfig, sys *e2esys.System) {
 		if ctx.Error != nil {
 			return
@@ -378,7 +378,7 @@ func SetHTTPClient(client *http.Client) EspressoDevNodeInterceptOption {
 
 // SetupQueryServiceIntercept sets up an intercept traffic headed for the
 // Query Service for the Espresso Dev Node
-func SetupQueryServiceIntercept(options ...EspressoDevNodeInterceptOption) (*EspressoDevNodeIntercept, *httptest.Server, DevNetLauncherOption) {
+func SetupQueryServiceIntercept(options ...EspressoDevNodeInterceptOption) (*EspressoDevNodeIntercept, *httptest.Server, E2eDevnetLauncherOption) {
 	// Start a Server to proxy requests to Espresso
 	proxy := &EspressoDevNodeIntercept{
 		client:  http.DefaultClient,
@@ -392,7 +392,7 @@ func SetupQueryServiceIntercept(options ...EspressoDevNodeInterceptOption) (*Esp
 	// Start up a local http server to handle the requests
 	server := httptest.NewServer(proxy)
 
-	return proxy, server, func(ctx *DevNetLauncherContext) E2eSystemOption {
+	return proxy, server, func(ctx *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			StartOptions: []e2esys.StartOption{
 				{


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1211528260952661?focus=true.

### This PR:
* Renames `DevNet` in function and struct names to `E2eDevnet` when it refers to the E2E devnet, to distinguish it from the Celo devnet with Docker Compose.
* Updates code comments accordingly.