### PR TITLE
Fix the logging level on the integration repo

### DIFF
--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -225,6 +225,7 @@ services:
       - --l1.http-poll-interval=1s
       - --l1.epoch-poll-interval=1s
       - --p2p.disable=true
+      - --log.level=debug
 
   op-node-verifier:
     build:
@@ -262,6 +263,7 @@ services:
       - --l1.http-poll-interval=1s
       - --l1.epoch-poll-interval=1s
       - --p2p.disable=true
+      - --log.level=debug
 
   caff-node:
     build:


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211735358500413?focus=true.

### This PR:
* Fix the logging level for the verifier and the sequencer so that the safe L2 progress can be shown on logs.