### PR TITLE
Remove unnecessary metrics

### DIFF
--- a/espresso/docs/metrics.md
+++ b/espresso/docs/metrics.md
@@ -21,10 +21,6 @@ Metrics that belong on the dashboard:
   `"Submitted transaction to Espresso"`
 - L1 batch submissions
   `"Transaction confirmed"`
-- Espresso transaction queue size
-  `"Espresso transaction submitter queue status"`
-- AltDA submissions
-  `"Sent txdata to altda layer and received commitment"`
 - Espresso batches fetched
   `"Inserting accepted batch"`
 


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211735359000834?focus=true.

### This PR:
* Removes `Espresso transaction submitter queue status` from the metrics because we don't check it.
* Removes `Sent txdata to altda layer and received commitment` since it never appears.