### PR TITLE
Rename numFinalizedBlocks and sendEspressoTx

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -1023,7 +1023,7 @@ func (l *BatchSubmitter) sendTx(txdata txData, isCancel bool, candidate *txmgr.T
 	if l.Config.UseEspresso && !isCancel {
 		l.teeAuthGroup.Go(
 			func() error {
-				l.sendEspressoTx(txdata, isCancel, candidate, queue, receiptsCh)
+				l.sendTxWithEspresso(txdata, isCancel, candidate, queue, receiptsCh)
 				return nil
 			},
 		)

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -892,13 +892,13 @@ func (l *BlockLoader) nextBlockRange(newSyncStatus *eth.SyncStatus) (inclusiveBl
 	}
 
 	if safeL2.Number > firstQueuedBlock.Number {
-		numFinalizedBlocks := safeL2.Number - firstQueuedBlock.Number
+		numFinalizedBlocksInQueue := safeL2.Number - firstQueuedBlock.Number
 		l.batcher.Log.Warn(
 			"Removing finalized blocks from queued",
-			"numFinalizedBlocks", numFinalizedBlocks,
+			"numFinalizedBlocksInQueue", numFinalizedBlocksInQueue,
 			"safeL2", safeL2,
 			"firstQueuedBlock", firstQueuedBlock)
-		l.queuedBlocks = l.queuedBlocks[numFinalizedBlocks:]
+		l.queuedBlocks = l.queuedBlocks[numFinalizedBlocksInQueue:]
 	}
 
 	return inclusiveBlockRange{lastQueuedBlock.Number + 1, newSyncStatus.UnsafeL2.Number}, ActionEnqueue
@@ -1111,9 +1111,9 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 	return nil
 }
 
-// sendEspressoTx uses the txmgr queue to send the given transaction candidate after setting its
-// gaslimit. It will block if the txmgr queue has reached its MaxPendingTransactions limit.
-func (l *BatchSubmitter) sendEspressoTx(txdata txData, isCancel bool, candidate *txmgr.TxCandidate, queue TxSender[txRef], receiptsCh chan txmgr.TxReceipt[txRef]) {
+// sendTxWithEspresso uses the txmgr queue to send the given transaction candidate after setting
+// its gaslimit. It will block if the txmgr queue has reached its MaxPendingTransactions limit.
+func (l *BatchSubmitter) sendTxWithEspresso(txdata txData, isCancel bool, candidate *txmgr.TxCandidate, queue TxSender[txRef], receiptsCh chan txmgr.TxReceipt[txRef]) {
 	transactionReference := txRef{id: txdata.ID(), isCancel: isCancel, isBlob: txdata.daType == DaTypeBlob}
 	l.Log.Debug("Sending Espresso-enabled L1 transaction", "txRef", transactionReference)
 


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211735359000849?focus=true.
Closes https://app.asana.com/1/1208976916964769/project/1209392461754458/task/1211084944387674?focus=true.

### This PR:
* Renames `numFinalizedBlocks` to `numFinalizedBlocksInQueue` as discussed: https://espressosys.slack.com/archives/C08RHAAJU6S/p1760557560948319?thread_ts=1760557557.680589&cid=C08RHAAJU6S.
* Renames `sendEspressoTx` to `sendTxWithEspresso` as discussed: https://espressosys.slack.com/archives/C08RHAAJU6S/p1755187998471699?thread_ts=1755187918.224809&cid=C08RHAAJU6S.