### PR TITLE
refactor: remove majority rule and switch to single Espresso client

### DIFF
--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -186,10 +186,8 @@ func BatchStreamerFromCLIConfig[B Batch](
 		return nil, fmt.Errorf("failed to dial Rollup L1 RPC at %s: %w", cfg.RollupL1URL, err)
 	}
 
-	espressoClient, err := espressoClient.NewMultipleNodesClient(cfg.QueryServiceURLs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Espresso client: %w", err)
-	}
+	urlZero := cfg.QueryServiceURLs[0]
+	espressoClient := espressoClient.NewClient(urlZero)
 
 	espressoLightClient, err := espressoLightClient.NewLightclientCaller(cfg.LightClientAddr, l1Client)
 	if err != nil {

--- a/espresso/environment/12_enforce_majority_rule_test.go
+++ b/espresso/environment/12_enforce_majority_rule_test.go
@@ -103,6 +103,7 @@ func runWithMultiClient(t *testing.T, numGoodUrls int, numBadUrls int, expectedE
 //
 //	If M>N, the chain should make progress, otherwise it should not.
 func TestEnforceMajorityRule(t *testing.T) {
+	t.Skip("Skipping test: MajorityRule has been deprecated and replaced by SingleNode.")
 
 	// To create a valid multiple nodes client, we need to provide at least 2 URLs.
 	runWithMultiClient(t, 2, 0, NO_ERROR_EXPECTED)

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -565,10 +565,9 @@ func (bs *BatcherService) initEspresso(cfg *CLIConfig) error {
 	bs.UseEspresso = true
 	bs.EspressoPollInterval = cfg.Espresso.PollInterval
 
-	espressoClient, err := espressoClient.NewMultipleNodesClient(cfg.Espresso.QueryServiceURLs)
-	if err != nil {
-		return fmt.Errorf("failed to create Espresso client: %w", err)
-	}
+	urlZero := cfg.Espresso.QueryServiceURLs[0]
+	espressoClient := espressoClient.NewClient(urlZero)
+
 	bs.EspressoClient = espressoClient
 
 	if err := bs.initKeyPair(); err != nil {


### PR DESCRIPTION
**Description**
This PR replaces the previous `NewMultipleNodesClient()` usage with a single-client configuration based on `NewClient()`

**Changes:**
- Removed majority-rule logic from cli.go and service,go
- Updated to initialise a `NewClient()` instance from the first `QueryServiceURLs` entry.

**Reasoning:**
- Current integration uses a duplicated URL value for `QueryServiceURLs`.
- The Asana ticket (“Remove majority rule”) requests deprecation of the multi-node client.
- `NewClient()` matches the desired simplified behaviour while keeping compatibility with the EspressoClient interface.

**Tests:**
- `just smoke-tests` → passed
- `just fast-tests`→ passed
- Code builds successfully inside Nix shell
- No changes to CLI/API surface

Let me know if you want any adjustments or a different approach.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211924412675745