### PR TITLE
CI isolation: NewClient refactor (debug branch) - Refactor/remove majority rule ci check

### DIFF
--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -1,7 +1,5 @@
 package espresso
 
-//dummy comment to trigger CI
-
 import (
 	"crypto/ecdsa"
 	"fmt"
@@ -188,10 +186,8 @@ func BatchStreamerFromCLIConfig[B Batch](
 		return nil, fmt.Errorf("failed to dial Rollup L1 RPC at %s: %w", cfg.RollupL1URL, err)
 	}
 
-	espressoClient, err := espressoClient.NewMultipleNodesClient(cfg.QueryServiceURLs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Espresso client: %w", err)
-	}
+	urlZero := cfg.QueryServiceURLs[0]
+	espressoClient := espressoClient.NewClient(urlZero)
 
 	espressoLightClient, err := espressoLightClient.NewLightclientCaller(cfg.LightClientAddr, l1Client)
 	if err != nil {

--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -1,5 +1,7 @@
 package espresso
 
+//dummy comment to trigger CI
+
 import (
 	"crypto/ecdsa"
 	"fmt"

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -565,10 +565,9 @@ func (bs *BatcherService) initEspresso(cfg *CLIConfig) error {
 	bs.UseEspresso = true
 	bs.EspressoPollInterval = cfg.Espresso.PollInterval
 
-	espressoClient, err := espressoClient.NewMultipleNodesClient(cfg.Espresso.QueryServiceURLs)
-	if err != nil {
-		return fmt.Errorf("failed to create Espresso client: %w", err)
-	}
+	urlZero := cfg.Espresso.QueryServiceURLs[0]
+	espressoClient := espressoClient.NewClient(urlZero)
+
 	bs.EspressoClient = espressoClient
 
 	if err := bs.initKeyPair(); err != nil {


### PR DESCRIPTION
**Description**

This branch contains the same code changes as the [original refactor pull 284](https://github.com/EspressoSystems/optimism-espresso-integration/pull/284) but isolated on a clean branch to investigate deterministic CI environment crashes (missing trie node).