### PR TITLE
Enable AltDA Espresso E2E using EigenDA Docker proxy

### DIFF
--- a/espresso/environment/espresso_dev_node_test.go
+++ b/espresso/environment/espresso_dev_node_test.go
@@ -119,6 +119,14 @@ func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 	launcher.AltDa = true
 
+	// Start a temporary EigenDA Docker instance for this test
+	eigenda, err := env.StartEigenDA(ctx)
+	if err != nil {
+		t.Fatalf("failed to start EigenDA: %v", err)
+	}
+	// Stopped when the test exits
+	defer env.StopDockerContainer(eigenda.ContainerID)
+
 	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -983,3 +983,50 @@ func WaitForEspressoTx(ctx context.Context, txHash *espressoCommon.TaggedBase64,
 		}
 	}
 }
+
+// --- EigenDA test helpers ---
+
+// StartEigenDA launches a temporary EigenDA proxy in Docker for use in tests.
+// It blocks until the proxy port is reachable or the context times out.
+func StartEigenDA(ctx context.Context) (*DockerContainerInfo, error) {
+	cli := new(DockerCli)
+
+	cfg := DockerContainerConfig{
+		Image:   "ghcr.io/layr-labs/eigenda-proxy:2.2.1",
+		Network: determineDockerNetworkMode(),
+		Environment: map[string]string{
+			"EIGENDA_PROXY_MEMSTORE_ENABLED": "true",
+			"PORT":                           "3100",
+		},
+		Ports: []string{"3100"},
+	}
+
+	container, err := cli.LaunchContainer(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait for port to be reachable
+	timeout, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	for {
+		select {
+		case <-timeout.Done():
+			return nil, fmt.Errorf("EigenDA proxy did not become ready")
+		default:
+			conn, err := net.DialTimeout("tcp", "localhost:3100", time.Second)
+			if err == nil {
+				conn.Close()
+				return &container, nil
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+}
+
+// StopDockerContainer stops a Docker container by ID.
+// Errors are ignored as this is best-effort test cleanup.
+func StopDockerContainer(id string) {
+	_ = new(DockerCli).StopContainer(context.Background(), id)
+}

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -74,6 +74,10 @@ const ESPRESSO_BUILDER_PORT = "31003"
 const ESPRESSO_SEQUENCER_API_PORT = "24000"
 const ESPRESSO_DEV_NODE_PORT = "24002"
 
+// EigenDA consstants
+const EIGENDA_DOCKER_PORT = "3100"
+const EIGENDA_DOCKER_IMAGE = "ghcr.io/layr-labs/eigenda-proxy:2.2.1"
+
 // ErrEspressoBlockHeightDidNotIncrease is a sentinel error that occurs when
 // the Espresso Block Height does not increase within the alloted context
 // allowance.
@@ -992,13 +996,13 @@ func StartEigenDA(ctx context.Context) (*DockerContainerInfo, error) {
 	cli := new(DockerCli)
 
 	cfg := DockerContainerConfig{
-		Image:   "ghcr.io/layr-labs/eigenda-proxy:2.2.1",
+		Image:   EIGENDA_DOCKER_IMAGE,
 		Network: determineDockerNetworkMode(),
 		Environment: map[string]string{
 			"EIGENDA_PROXY_MEMSTORE_ENABLED": "true",
-			"PORT":                           "3100",
+			"PORT":                           EIGENDA_DOCKER_PORT,
 		},
-		Ports: []string{"3100"},
+		Ports: []string{EIGENDA_DOCKER_PORT},
 	}
 
 	container, err := cli.LaunchContainer(ctx, cfg)
@@ -1015,7 +1019,7 @@ func StartEigenDA(ctx context.Context) (*DockerContainerInfo, error) {
 		case <-timeout.Done():
 			return nil, fmt.Errorf("EigenDA proxy did not become ready")
 		default:
-			conn, err := net.DialTimeout("tcp", "localhost:3100", time.Second)
+			conn, err := net.DialTimeout("tcp", "localhost:"+EIGENDA_DOCKER_PORT, time.Second)
 			if err == nil {
 				conn.Close()
 				return &container, nil

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -85,9 +85,10 @@ import (
 )
 
 const (
-	RoleSeq   = "sequencer"
-	RoleVerif = "verifier"
-	RoleL1    = "l1"
+	RoleSeq                      = "sequencer"
+	RoleVerif                    = "verifier"
+	RoleL1                       = "l1"
+	EIGENDA_DOCKER_DA_SERVER_URL = "http://127.0.0.1:3100"
 )
 
 var (
@@ -888,7 +889,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		// Configured for EigenDA (Docker-based proxy)
 		altDACLIConfig = altda.CLIConfig{
 			Enabled:               true,
-			DAServerURL:           "http://127.0.0.1:3100",
+			DAServerURL:           EIGENDA_DOCKER_DA_SERVER_URL,
 			VerifyOnRead:          true,
 			GenericDA:             true, // IMPORTANT: OP Stack expects GenericCommitment for EigenDA
 			MaxConcurrentRequests: cfg.BatcherMaxConcurrentDARequest,

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -885,19 +885,12 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	// The altDACLIConfig is shared by the batcher and rollup nodes.
 	var altDACLIConfig altda.CLIConfig
 	if cfg.DeployConfig.UseAltDA {
-		panic("****** DEBUG: forced panic in setup.go to verify test invocation path")
-		fakeAltDAServer := altda.NewFakeDAServer("127.0.0.1", 0, sys.Cfg.Loggers["da-server"])
-		if err := fakeAltDAServer.Start(); err != nil {
-			return nil, fmt.Errorf("failed to start fake altDA server: %w", err)
-		}
-		sys.FakeAltDAServer = fakeAltDAServer
-
+		// Configured for EigenDA (Docker-based proxy)
 		altDACLIConfig = altda.CLIConfig{
-			Enabled: cfg.DeployConfig.UseAltDA,
-			//DAServerURL:         fakeAltDAServer.HttpEndpoint(),
-			DAServerURL:           "http://127.0.0.1:9999", // unreachable on purpose
+			Enabled:               true,
+			DAServerURL:           "http://127.0.0.1:3100",
 			VerifyOnRead:          true,
-			GenericDA:             true,
+			GenericDA:             true, // IMPORTANT: OP Stack expects GenericCommitment for EigenDA
 			MaxConcurrentRequests: cfg.BatcherMaxConcurrentDARequest,
 		}
 	}

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -885,6 +885,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	// The altDACLIConfig is shared by the batcher and rollup nodes.
 	var altDACLIConfig altda.CLIConfig
 	if cfg.DeployConfig.UseAltDA {
+		panic("****** DEBUG: forced panic in setup.go to verify test invocation path")
 		fakeAltDAServer := altda.NewFakeDAServer("127.0.0.1", 0, sys.Cfg.Loggers["da-server"])
 		if err := fakeAltDAServer.Start(); err != nil {
 			return nil, fmt.Errorf("failed to start fake altDA server: %w", err)
@@ -892,8 +893,9 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		sys.FakeAltDAServer = fakeAltDAServer
 
 		altDACLIConfig = altda.CLIConfig{
-			Enabled:               cfg.DeployConfig.UseAltDA,
-			DAServerURL:           fakeAltDAServer.HttpEndpoint(),
+			Enabled: cfg.DeployConfig.UseAltDA,
+			//DAServerURL:         fakeAltDAServer.HttpEndpoint(),
+			DAServerURL:           "http://127.0.0.1:9999", // unreachable on purpose
 			VerifyOnRead:          true,
 			GenericDA:             true,
 			MaxConcurrentRequests: cfg.BatcherMaxConcurrentDARequest,


### PR DESCRIPTION
**Description**
This PR switches the AltDA path used by the Espresso environment E2E test to use a real EigenDA proxy (Docker) instead of FakeDA, and ensures EigenDA is started/stopped automatically as part of the test lifecycle.

**Changes**
- **op-e2e AltDA** config: Updated `op-e2e/system/e2esys/setup.go` to initialize `altDACLIConfig` against the EigenDA proxy.
- **Test-scoped EigenDA proxy**: Updated `espresso/environment/espresso_dev_node_test.go `(`TestE2eDevnetWithEspressoAndAltDaSimpleTransactions`) to: runs an EigenDA Docker proxy scoped to the test lifecycle. 
- **Test helpers**: Added helpers in `espresso/environment/optimism_espresso_test_helpers.go` to:
  - `StartEigenDA(ctx)` starts a temporary EigenDA Docker proxy and waits until it’s ready
  - `StopDockerContainer(id)` ensures the proxy is stopped when the test finishes

**Notes**
- EigenDA proxy is pinned to `:2.2.1` and uses the in-memory memstore mode.
- Only the Espresso environment AltDA E2E test depends on this path today.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212148617379211