### PR TITLE
Make ZK Verifier Optional for E2E Testing

### DIFF
--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -74,6 +74,51 @@ To run the devnet tests:
 > just devnet-tests
 ```
 
+#### Espresso Attestation Verifier
+The Espresso Attestation Verifier is utilized to register Attestations for the
+Builder. For the E2E Testnet (utilized in local testing) this is provided as
+an opt-in configuration.  The live Batcher is expected to run with this
+enabled and configured.  If it is not configured and we have an Attestation
+a warning log will be issued.
+
+In order to enable the Espresso Attestation Verifier in the local E2E tests
+you merely need to include the relevant option in the configuration as an
+option:
+
+```go
+
+	system, _, err := launcher.StartE2eDevnet(ctx, t,
+		env.WithEspressoAttestationVerifierService(),
+	)
+```
+
+|> NOTE: This configuration has default values configured for convenience
+  and to make the Attestation Verifier Service launch without any external
+  configuration being required.  However, the option itself can also take
+  options that allow the values to be overridden.
+  Additionally, to preserve the previous behavior of the Attestation Verifier
+  it also supports configuration via the same Environment Variables that
+  were previously required.
+
+These environment variables are set in the [espresso/.env](espresso/.env) file for reference.
+However for clarity they are listed here.  These values will only be used
+in the testing when they are populated to a non-empty value.
+
+```env
+ESPRESSO_ATTESTATION_VERIFIER_PORT=<The port to host the verifier service on>
+ESPRESSO_ATTESTATION_VERIFIER_RPC_URL=<The RPC URL to communicate with>
+ESPRESSO_ATTESTATION_VERIFIER_SP1_PROVER=<The SP1 Prover mode to operate in>
+ESPRESSO_ATTESTATION_VERIFIER_NITRO_VERIFIER_ADDRESS=<The nitro verfier address>
+ESPRESSO_ATTESTATION_VERIFIER_SKIP_TIME_VALIDITY_CHECK=<whether or not to enable the validity check>
+ESPRESSO_ATTESTATION_VERIFIER_HOST=<The host to listen for. Meant to be the bind address, best if "0.0.0.0 is used>
+ESPRESSO_ATTESTATION_VERIFIER_NETWORK_PRIVATE_KEY=<The hex encoded private key to utilize>
+ESPRESSO_ATTESTATION_VERIFIER_NETWORK_RPC_URL=<The Network RPC URL to utilize>
+ESPRESSO_ATTESTATION_VERIFIER_NETWORK_USE_DOCKER=<Whether or not to use docker for the attestation verifier. "1  or "0">
+ESPRESSO_ATTESTATION_VERIFIER_RUST_LOG=<The RUST_LOG level to pass to the service>
+ESPRESSO_ATTESTATION_VERIFIER_DOCKER_IMAGE=<The Docker Image to utilize for the attestation verifier service>
+```
+
+
 ### Misc commands
 
 In order to run the go linter do:

--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -182,7 +182,10 @@ func (c CLIConfig) Check() error {
 		if c.Namespace == 0 {
 			return fmt.Errorf("namespace is required when Espresso is enabled")
 		}
-		if c.EspressoAttestationService == nil || !c.EspressoAttestationService.AllowEmpty() && c.EspressoAttestationService.Value() == "" {
+		if c.EspressoAttestationService == nil {
+			return fmt.Errorf("attestation service URL is not set to any value")
+		}
+		if !c.EspressoAttestationService.AllowEmpty() && c.EspressoAttestationService.Value() == "" {
 			return fmt.Errorf("attestation service URL is required when Espresso is enabled")
 		}
 	}

--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -121,6 +121,34 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 	}
 }
 
+// ConfigurationStringValue represents a configurable value for configuration.
+// The point is that the underlying value is representable as a `string`,
+// and is usually required. However, this allows for the potential of the
+// value to potentially be optional for testing purposes.
+// Value represents the underlying value of the option as a `string`.
+type ConfigurationStringValue interface {
+	Value() string
+
+	// AllowEmpty specifies whether this configuration is allowed to be
+	// empty or not.
+	AllowEmpty() bool
+}
+
+// ConfigurationValue is a simple `string` wrapper that implements
+// ConfigurationStringValue.  The default implementation of this value
+// does not allow for it to be empty.
+type ConfigurationValue string
+
+// Value implements ConfigurationStringValue.
+func (c ConfigurationValue) Value() string {
+	return string(c)
+}
+
+// AllowEmpty implements ConfigurationStringValue.
+func (ConfigurationValue) AllowEmpty() bool {
+	return false
+}
+
 type CLIConfig struct {
 	Enabled                    bool
 	PollInterval               time.Duration
@@ -133,7 +161,7 @@ type CLIConfig struct {
 	Namespace                  uint64
 	CaffeinationHeightEspresso uint64
 	CaffeinationHeightL2       uint64
-	EspressoAttestationService string
+	EspressoAttestationService ConfigurationStringValue
 }
 
 func (c CLIConfig) Check() error {
@@ -154,6 +182,9 @@ func (c CLIConfig) Check() error {
 		if c.Namespace == 0 {
 			return fmt.Errorf("namespace is required when Espresso is enabled")
 		}
+		if c.EspressoAttestationService == nil || !c.EspressoAttestationService.AllowEmpty() && c.EspressoAttestationService.Value() == "" {
+			return fmt.Errorf("attestation service URL is required when Espresso is enabled")
+		}
 	}
 	return nil
 }
@@ -168,7 +199,7 @@ func ReadCLIConfig(c *cli.Context) CLIConfig {
 		Namespace:                  c.Uint64(NamespaceFlagName),
 		CaffeinationHeightEspresso: c.Uint64(CaffeinationHeightEspresso),
 		CaffeinationHeightL2:       c.Uint64(CaffeinationHeightL2),
-		EspressoAttestationService: c.String(AttestationServiceFlagName),
+		EspressoAttestationService: ConfigurationValue(c.String(AttestationServiceFlagName)),
 	}
 
 	config.QueryServiceURLs = c.StringSlice(QueryServiceUrlsFlagName)

--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -121,34 +121,6 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 	}
 }
 
-// ConfigurationStringValue represents a configurable value for configuration.
-// The point is that the underlying value is representable as a `string`,
-// and is usually required. However, this allows for the potential of the
-// value to potentially be optional for testing purposes.
-// Value represents the underlying value of the option as a `string`.
-type ConfigurationStringValue interface {
-	Value() string
-
-	// AllowEmpty specifies whether this configuration is allowed to be
-	// empty or not.
-	AllowEmpty() bool
-}
-
-// ConfigurationValue is a simple `string` wrapper that implements
-// ConfigurationStringValue.  The default implementation of this value
-// does not allow for it to be empty.
-type ConfigurationValue string
-
-// Value implements ConfigurationStringValue.
-func (c ConfigurationValue) Value() string {
-	return string(c)
-}
-
-// AllowEmpty implements ConfigurationStringValue.
-func (ConfigurationValue) AllowEmpty() bool {
-	return false
-}
-
 type CLIConfig struct {
 	Enabled                    bool
 	PollInterval               time.Duration
@@ -161,7 +133,18 @@ type CLIConfig struct {
 	Namespace                  uint64
 	CaffeinationHeightEspresso uint64
 	CaffeinationHeightL2       uint64
-	EspressoAttestationService ConfigurationStringValue
+	EspressoAttestationService string
+
+	// Non directly configurable option
+	allowEmptyAttestationService bool `json:"-"`
+}
+
+// AllowEmptyAttestationService allows the attestation service URL to be
+// empty. This is set explicitly from a public method, and isn't derivable
+// from serialization or any other form other than this method.  This allows
+// this setting to be configured via the code, but not externally.
+func (c *CLIConfig) AllowEmptyAttestationService() {
+	c.allowEmptyAttestationService = true
 }
 
 func (c CLIConfig) Check() error {
@@ -182,10 +165,7 @@ func (c CLIConfig) Check() error {
 		if c.Namespace == 0 {
 			return fmt.Errorf("namespace is required when Espresso is enabled")
 		}
-		if c.EspressoAttestationService == nil {
-			return fmt.Errorf("attestation service URL is not set to any value")
-		}
-		if !c.EspressoAttestationService.AllowEmpty() && c.EspressoAttestationService.Value() == "" {
+		if !c.allowEmptyAttestationService && c.EspressoAttestationService == "" {
 			return fmt.Errorf("attestation service URL is required when Espresso is enabled")
 		}
 	}
@@ -202,7 +182,7 @@ func ReadCLIConfig(c *cli.Context) CLIConfig {
 		Namespace:                  c.Uint64(NamespaceFlagName),
 		CaffeinationHeightEspresso: c.Uint64(CaffeinationHeightEspresso),
 		CaffeinationHeightL2:       c.Uint64(CaffeinationHeightL2),
-		EspressoAttestationService: ConfigurationValue(c.String(AttestationServiceFlagName)),
+		EspressoAttestationService: c.String(AttestationServiceFlagName),
 	}
 
 	config.QueryServiceURLs = c.StringSlice(QueryServiceUrlsFlagName)

--- a/espresso/cli.go
+++ b/espresso/cli.go
@@ -154,9 +154,6 @@ func (c CLIConfig) Check() error {
 		if c.Namespace == 0 {
 			return fmt.Errorf("namespace is required when Espresso is enabled")
 		}
-		if c.EspressoAttestationService == "" {
-			return fmt.Errorf("attestation service URL is required when Espresso is enabled")
-		}
 	}
 	return nil
 }

--- a/espresso/enclave-tests/enclave_smoke_test.go
+++ b/espresso/enclave-tests/enclave_smoke_test.go
@@ -27,9 +27,11 @@ func TestE2eDevnetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 	env.RunOnlyWithEnclave(t)
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
-	launcher.EnclaveBatcher = true
-
-	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(
+		ctx,
+		t,
+		env.LaunchBatcherInEnclave(),
+	)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -42,5 +44,4 @@ func TestE2eDevnetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 
 	// Submit a Transaction on the L2 Sequencer node, to a Burn Address
 	env.RunSimpleL2Burn(ctx, t, system)
-
 }

--- a/espresso/enclave-tests/enclave_smoke_test.go
+++ b/espresso/enclave-tests/enclave_smoke_test.go
@@ -31,6 +31,7 @@ func TestE2eDevnetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 		ctx,
 		t,
 		env.LaunchBatcherInEnclave(),
+		env.WithEspressoAttestationVerifierService(),
 	)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/enclave-tests/enclave_smoke_test.go
+++ b/espresso/enclave-tests/enclave_smoke_test.go
@@ -31,7 +31,6 @@ func TestE2eDevnetWithEspressoAndEnclaveSimpleTransactions(t *testing.T) {
 		ctx,
 		t,
 		env.LaunchBatcherInEnclave(),
-		env.WithEspressoAttestationVerifierService(),
 	)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)

--- a/espresso/environment/13_dispute_game_test.go
+++ b/espresso/environment/13_dispute_game_test.go
@@ -38,12 +38,12 @@ func TestOutputAlphabetGameWithEspresso_ChallengerWins(t *testing.T) {
 	// Start a Fault Dispute System with Espresso Dev Node
 	sys, espressoDevNode, err := launcher.StartE2eDevnetWithFaultDisputeSystem(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
 
-	l1Client := sys.NodeClient("l1")
-
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
+
+	l1Client := sys.NodeClient("l1")
 
 	// Close the system and stop the Espresso Dev Node
 	defer sys.Close()

--- a/espresso/environment/13_dispute_game_test.go
+++ b/espresso/environment/13_dispute_game_test.go
@@ -36,7 +36,13 @@ func TestOutputAlphabetGameWithEspresso_ChallengerWins(t *testing.T) {
 	launcher := new(env.EspressoDevNodeLauncherDocker)
 
 	// Start a Fault Dispute System with Espresso Dev Node
-	sys, espressoDevNode, err := launcher.StartE2eDevnetWithFaultDisputeSystem(ctx, t, env.WithL1FinalizedDistance(0), env.WithSequencerUseFinalized(true))
+	sys, espressoDevNode, err := launcher.StartE2eDevnet(
+		ctx,
+		t,
+		env.WithFaultDisputeSystem(),
+		env.WithL1FinalizedDistance(0),
+		env.WithSequencerUseFinalized(true),
+	)
 
 	// Signal the testnet to shut down
 	if have, want := err, error(nil); have != want {

--- a/espresso/environment/5_batch_authentication_test.go
+++ b/espresso/environment/5_batch_authentication_test.go
@@ -27,13 +27,13 @@ func TestE2eDevnetWithInvalidAttestation(t *testing.T) {
 		t.Fatalf("failed to generate private key")
 	}
 
-	system, _, err :=
-		launcher.StartE2eDevnet(ctx, t,
-			env.SetBatcherKey(*privateKey),
-			env.Config(func(cfg *e2esys.SystemConfig) {
-				cfg.DisableBatcher = true
-			}),
-		)
+	system, _, err := launcher.StartE2eDevnet(ctx, t,
+		env.SetBatcherKey(*privateKey),
+		env.Config(func(cfg *e2esys.SystemConfig) {
+			cfg.DisableBatcher = true
+		}),
+		env.WithEspressoAttestationVerifierService(),
+	)
 
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
@@ -74,10 +74,10 @@ func TestE2eDevnetWithUnattestedBatcherKey(t *testing.T) {
 		t.Fatalf("failed to parse private key: %v", err)
 	}
 
-	system, _, err :=
-		launcher.StartE2eDevnet(ctx, t,
-			env.SetBatcherKey(*privateKey),
-		)
+	system, _, err := launcher.StartE2eDevnet(ctx, t,
+		env.SetBatcherKey(*privateKey),
+		env.WithEspressoAttestationVerifierService(),
+	)
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}

--- a/espresso/environment/attestation_verifier_service_helpers.go
+++ b/espresso/environment/attestation_verifier_service_helpers.go
@@ -1,0 +1,431 @@
+package environment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+)
+
+// ErrorAttestationConfigFieldNotSet
+type ErrorAttestationConfigFieldNotSet struct {
+	FieldName string
+}
+
+// Error implements error
+func (e ErrorAttestationConfigFieldNotSet) Error() string {
+	return fmt.Sprintf("\"%s\" is not set for \"AttestationVerifierServiceConfig\"", e.FieldName)
+}
+
+// AttestationVerifierServiceConfig is a struct that contatins all of the
+// configuration options / values for the Attestation Verifier Service
+// configuration.
+type AttestationVerifierServiceConfig struct {
+	networkRPCURL         string
+	sp1Prover             string
+	nitroVerifierAddress  string
+	networkUseDocker      string
+	skipTimeValidityCheck string
+	rustLog               string
+	networkPrivateKey     string
+	rpcURL                string
+	host                  string
+	port                  string
+	dockerImage           string
+}
+
+// applyOptions is a convenience method for quickly applying options against
+// the configuration.
+func (c *AttestationVerifierServiceConfig) applyOptions(options ...AttestationVerifierServiceOption) {
+	for _, opt := range options {
+		opt(c)
+	}
+}
+
+// Verify performs a basic verification of the values stored within the
+// AttestationVerifierServiceConfig struct.
+func (c *AttestationVerifierServiceConfig) Verify(ct *E2eDevnetLauncherContext) {
+	if ct.Error != nil {
+		// Early Return if we already have an Error set
+		return
+	}
+
+	// Now launch the attestation verifier zk server
+	// Now we need to launch the attestation verifier zk server
+	fmt.Println("Starting attestation verifier zk server...")
+
+	if c.networkRPCURL == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"networkRPCURL"}
+		return
+	}
+
+	if c.sp1Prover == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"sp1Prover"}
+		return
+	}
+
+	if c.nitroVerifierAddress == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"nitroVerifierAddress"}
+		return
+	}
+
+	if c.networkUseDocker == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"networkUseDocker"}
+		return
+	}
+
+	if c.skipTimeValidityCheck == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"skipTimeValidityCheck"}
+		return
+	}
+
+	if c.rustLog == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"rustLog"}
+		return
+	}
+
+	if c.networkPrivateKey == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"networkPrivateKey"}
+		return
+	}
+
+	if c.rpcURL == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"rpcURL"}
+		return
+	}
+
+	if c.host == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"host"}
+		return
+	}
+
+	if c.port == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"port"}
+		return
+	}
+
+	if c.dockerImage == "" {
+		ct.Error = ErrorAttestationConfigFieldNotSet{"dockerImage"}
+		return
+	}
+}
+
+// AttestationVerifierServiceOption represents a functional option that allows
+// for the modification / configuration of the Attestation Verifier Service
+// in a flexible manner.
+type AttestationVerifierServiceOption func(*AttestationVerifierServiceConfig)
+
+// WithAttestationServiceVerifierNetworkRPCURL configures the Network RPC URL
+// for the Attestation Verifier Service.
+func WithAttestationServiceVerifierNetworkRPCURL(networkRPCURL string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.networkRPCURL = networkRPCURL
+	}
+}
+
+// WithAttestationServiceVerifierSP1Prover configures the SP1 Provider
+// for the Attstation Verifier Service.
+func WithAttestationServiceVerifierSP1Prover(sp1Prover string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.sp1Prover = sp1Prover
+	}
+}
+
+// WithAttestationServiceVerifierNitroVerifierAddress configures the
+// Nitro Verifier Address for the Attestation Verifier Service
+func WithAttestationServiceVerifierNitroVerifierAddress(nitroVerifierAddress string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.nitroVerifierAddress = nitroVerifierAddress
+	}
+}
+
+// WithAttestationServiceVerifierNetworkUseDocker configures the
+// Netowrk Use Docker configuration for the Attestation Verifier Service.
+func WithAttestationServiceVerifierNetworkUseDocker(networkUseDocker string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.networkUseDocker = networkUseDocker
+	}
+}
+
+// WithAttestationServiceVerifierSkipTimeValidityCheck configures the
+// Skip Time Validity Check configuration for the Attestation Verifier
+// Service.
+func WithAttestationServiceVerifierSkipTimeValidityCheck(skipTimeValidityCheck string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.skipTimeValidityCheck = skipTimeValidityCheck
+	}
+}
+
+// WithAttestationServiceVerifierRustLog configures the Rust Log
+// configuration for the Attestation Verifier Service.
+func WithAttestationServiceVerifierRustLog(rustLog string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.rustLog = rustLog
+	}
+}
+
+// WithAttestationServiceVerifierNetworkPrivateKey configurs the network
+// private key for the Attestation Verifier Service.
+func WithAttestationServiceVerifierNetworkPrivateKey(networkPrivateKey string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.networkPrivateKey = networkPrivateKey
+	}
+}
+
+// WithAttestationServiceVerifierRPCURL configures the RPC URL for the
+// AttestationVerifier Service.
+func WithAttestationServiceVerifierRPCURL(rpcURL string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.rpcURL = rpcURL
+	}
+}
+
+// WithAttestationServiceVerifierHost configures the Host configuration for
+// the Attestation Verifier Service.
+func WithAttestationServiceVerifierHost(host string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.host = host
+	}
+}
+
+// WithAttestationServiceVerifierPort configures the Port configuration for
+// the Attestation Verifier Service.
+func WithAttestationServiceVerifierPort(port string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.port = port
+	}
+}
+
+// WithAttestationServiceVerifierDockerImage configures the Docker Image
+// configuration for the Attestation Verifier SErvice.
+func WithAttestationServiceVerifierDockerImage(dockerImage string) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.dockerImage = dockerImage
+	}
+}
+
+// WithAttestationServiceVerifierOptions applies multiple options as a single
+// option.  This is provided for convenience, and nothing else.
+func WithAttestationServiceVerifierOptions(options ...AttestationVerifierServiceOption) AttestationVerifierServiceOption {
+	return func(c *AttestationVerifierServiceConfig) {
+		c.applyOptions(options...)
+	}
+}
+
+// WithAttestationConfigFromENV is an option that will populate and overwrite
+// the configuration for the Attestation Service Verifier with values taken
+// from the ENV variables, should they be present.
+func WithAttestationConfigFromENV() AttestationVerifierServiceOption {
+	var options []AttestationVerifierServiceOption
+
+	if networkRPCURL := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_RPC_URL"); networkRPCURL != "" {
+		options = append(options, WithAttestationServiceVerifierNetworkRPCURL(networkRPCURL))
+	}
+
+	if sp1Prover := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_SP1_PROVER"); sp1Prover != "" {
+		options = append(options, WithAttestationServiceVerifierSP1Prover(sp1Prover))
+	}
+
+	if nitroVerifierAddress := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NITRO_VERIFIER_ADDRESS"); nitroVerifierAddress != "" {
+		options = append(options, WithAttestationServiceVerifierNitroVerifierAddress(nitroVerifierAddress))
+	}
+
+	if useDocker := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_USE_DOCKER"); useDocker != "" {
+		options = append(options, WithAttestationServiceVerifierNetworkUseDocker(useDocker))
+	}
+
+	if skipTimeValidityCheck := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_SKIP_TIME_VALIDITY_CHECK"); skipTimeValidityCheck != "" {
+		options = append(options, WithAttestationServiceVerifierSkipTimeValidityCheck(skipTimeValidityCheck))
+	}
+
+	if rustLog := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_RUST_LOG"); rustLog != "" {
+		options = append(options, WithAttestationServiceVerifierRustLog(rustLog))
+	}
+
+	if networkPrivateKey := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_PRIVATE_KEY"); networkPrivateKey != "" {
+		options = append(options, WithAttestationServiceVerifierNetworkPrivateKey(networkPrivateKey))
+	}
+
+	if rpcUrl := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_RPC_URL"); rpcUrl != "" {
+		options = append(options, WithAttestationServiceVerifierRPCURL(rpcUrl))
+	}
+
+	if host := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_HOST"); host != "" {
+		options = append(options, WithAttestationServiceVerifierHost(host))
+	}
+
+	if port := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_PORT"); port != "" {
+		options = append(options, WithAttestationServiceVerifierPort(port))
+	}
+
+	if dockerImage := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_DOCKER_IMAGE"); dockerImage != "" {
+		options = append(options, WithAttestationServiceVerifierDockerImage(dockerImage))
+	}
+
+	return WithAttestationServiceVerifierOptions(options...)
+}
+
+// launchEspressoAttestationVerifierServiceDockerContainer is a StartOption that
+// ensures that the Espresso Attestation Verifier Service is launched in its
+// own docker container.
+//
+// It will launch the service, and modify the Batcher CLIConfig with the
+// configured parameters.
+func launchEspressoAttestationVerifierServiceDockerContainer(ct *E2eDevnetLauncherContext, options ...AttestationVerifierServiceOption) e2esys.StartOption {
+	return e2esys.StartOption{
+		Role: "launch-espresso-attestation-verifier",
+		BatcherMod: func(c *batcher.CLIConfig, sys *e2esys.System) {
+			if ct.Error != nil {
+				// Early Return if we already have an Error set
+				return
+			}
+
+			// These are the default configuration values.
+			// These values are based on those contained within the
+			// ".env" file.
+			cfg := AttestationVerifierServiceConfig{
+				networkRPCURL:         "https://rpc.mainnet.succinct.xyz",
+				sp1Prover:             "mock",
+				nitroVerifierAddress:  "0x2D7fbBAD6792698Ba92e67b7e180f8010B9Ec788",
+				networkUseDocker:      "1",
+				skipTimeValidityCheck: "true",
+				rustLog:               "string",
+				networkPrivateKey:     "0x71f8e55f7555c946eadd5a2b5897465a9813b3ee493d6ef4ba6f1505a6e97af3",
+				rpcURL:                "https://rpc.ankr.com/eth_sepolia/ece75e2d2d01c537031b3b31a619b7830674b9cd1b9fe6bc957a3d393c035dbb",
+				host:                  "0.0.0.0",
+				port:                  "8080",
+				dockerImage:           "ghcr.io/espressosystems/attestation-verifier-zk:sha-f5d0a46",
+			}
+
+			// Apply all Environment Variable modifications
+			cfg.applyOptions(WithAttestationConfigFromENV())
+
+			// Apply the options
+			cfg.applyOptions(options...)
+
+			// Verify the options
+			cfg.Verify(ct)
+
+			if ct.Error != nil {
+				// Early return, as we have an error in our configuration
+				return
+			}
+
+			dockerConfig := DockerContainerConfig{
+				Image:   cfg.dockerImage,
+				Network: determineDockerNetworkMode(),
+				Ports: []string{
+					cfg.port,
+				},
+				Name: "attestation-verifier-zk",
+				Environment: map[string]string{
+					"NETWORK_RPC_URL":          cfg.networkRPCURL,
+					"SP1_PROVER":               cfg.sp1Prover,
+					"NITRO_VERIFIER_ADDRESS":   cfg.nitroVerifierAddress,
+					"USE_DOCKER":               cfg.networkUseDocker,
+					"SKIP_TIME_VALIDITY_CHECK": cfg.skipTimeValidityCheck,
+					"RUST_LOG":                 cfg.rustLog,
+					"NETWORK_PRIVATE_KEY":      cfg.networkPrivateKey,
+					"RPC_URL":                  cfg.rpcURL,
+					"HOST":                     cfg.host,
+					"PORT":                     cfg.port,
+				},
+			}
+			containerCli := new(DockerCli)
+
+			attestationVerifierInfo, err := containerCli.LaunchContainer(ct.Ctx, dockerConfig)
+			if err != nil {
+				ct.Error = FailedToLaunchDockerContainer{Cause: err}
+				return
+			}
+
+			// Get the actual mapped port
+			ports := attestationVerifierInfo.PortMap[cfg.port]
+			if len(ports) == 0 {
+				ct.Error = fmt.Errorf("no port mapping found for attestation verifier")
+				return
+			}
+
+			healthCheckCtx, cancel := context.WithTimeout(ct.Ctx, 60*time.Second)
+			defer cancel()
+
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+			attestationHostPort, err := getContainerRemappedHostPort(ports[0])
+			if err != nil {
+				ct.Error = err
+				return
+			}
+
+			// Use the actual host:port for health check
+			attestationURL := "http://" + attestationHostPort
+
+			// Replace the EspressoDevNode with the wrapped Dev Node,
+			// so we can tie into the cleanup stage.
+			ct.EspressoDevNode = &EspressoDevNodeWithAttestationVerifier{
+				EspressoDevNode:            ct.EspressoDevNode,
+				AttestationVerifierService: attestationVerifierInfo,
+			}
+
+			c.Espresso.EspressoAttestationService = attestationURL
+			healthCheckURL := attestationURL + "/health"
+			for {
+				select {
+				case <-healthCheckCtx.Done():
+					ct.Error = fmt.Errorf("attestation verifier did not become healthy: %w", healthCheckCtx.Err())
+					return
+				case <-ticker.C:
+					resp, err := http.Get(healthCheckURL)
+					if resp != nil {
+						resp.Body.Close()
+					}
+
+					if err == nil && resp.StatusCode == http.StatusOK {
+						// We are done waiting, we have a good response, and
+						// the service seems to be healthy
+						return
+					}
+				}
+			}
+		},
+	}
+}
+
+// WithEspressoAttestationVerifierService is a Devnet option that ensures that
+// the Docker Container image is up and running before the Batcher is
+// launched.
+func WithEspressoAttestationVerifierService() E2eDevnetLauncherOption {
+	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
+		return E2eSystemOption{
+			StartOptions: []e2esys.StartOption{
+				launchEspressoAttestationVerifierServiceDockerContainer(ct),
+			},
+		}
+	}
+}
+
+// EspressoDevNodeWithAttestationVerifier  is a simple struct meant to wrap
+// an existing EspressoDevNode and add its own container for reference and
+// removal on cleanup.
+type EspressoDevNodeWithAttestationVerifier struct {
+	EspressoDevNode
+	AttestationVerifierService DockerContainerInfo
+}
+
+// Stop overwrites and implements EspressoDevNode
+func (w *EspressoDevNodeWithAttestationVerifier) Stop() error {
+	dockerCli := new(DockerCli)
+
+	err := dockerCli.StopContainer(context.Background(), w.AttestationVerifierService.ContainerID)
+
+	// Always try to shut down the Espresso Dev Node
+	if err := w.EspressoDevNode.Stop(); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/espresso/environment/attestation_verifier_service_helpers.go
+++ b/espresso/environment/attestation_verifier_service_helpers.go
@@ -7,11 +7,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/espresso"
 	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 )
 
-// ErrorAttestationConfigFieldNotSet
+// ErrorAttestationConfigFieldNotSet is an error that indicates that specific
+// configuration value for the AttestationVerifierServiceConfig struct
+// is not set.
 type ErrorAttestationConfigFieldNotSet struct {
 	FieldName string
 }
@@ -250,8 +253,8 @@ func WithAttestationConfigFromENV() AttestationVerifierServiceOption {
 		options = append(options, WithAttestationServiceVerifierNetworkPrivateKey(networkPrivateKey))
 	}
 
-	if rpcUrl := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_RPC_URL"); rpcUrl != "" {
-		options = append(options, WithAttestationServiceVerifierRPCURL(rpcUrl))
+	if rpcURL := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_RPC_URL"); rpcURL != "" {
+		options = append(options, WithAttestationServiceVerifierRPCURL(rpcURL))
 	}
 
 	if host := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_HOST"); host != "" {
@@ -267,6 +270,23 @@ func WithAttestationConfigFromENV() AttestationVerifierServiceOption {
 	}
 
 	return WithAttestationServiceVerifierOptions(options...)
+}
+
+// AllowEmptyConfigurationValue is a simple string wrapper that is meant
+// to adhere to the espresso.ConfigurationStringValue interface, that allows
+// for the value to be empty.
+type AllowEmptyConfigurationValue string
+
+var _ espresso.ConfigurationStringValue = AllowEmptyConfigurationValue("")
+
+// Value implements ConfigurationStringValue.
+func (a AllowEmptyConfigurationValue) Value() string {
+	return string(a)
+}
+
+// AllowEmpty implements ConfigurationStringValue.
+func (AllowEmptyConfigurationValue) AllowEmpty() bool {
+	return true
 }
 
 // launchEspressoAttestationVerifierServiceDockerContainer is a StartOption that
@@ -371,7 +391,7 @@ func launchEspressoAttestationVerifierServiceDockerContainer(ct *E2eDevnetLaunch
 				AttestationVerifierService: attestationVerifierInfo,
 			}
 
-			c.Espresso.EspressoAttestationService = attestationURL
+			c.Espresso.EspressoAttestationService = espresso.ConfigurationValue(attestationURL)
 			healthCheckURL := attestationURL + "/health"
 			for {
 				select {
@@ -381,7 +401,7 @@ func launchEspressoAttestationVerifierServiceDockerContainer(ct *E2eDevnetLaunch
 				case <-ticker.C:
 					resp, err := http.Get(healthCheckURL)
 					if resp != nil {
-						resp.Body.Close()
+						_ = resp.Body.Close()
 					}
 
 					if err == nil && resp.StatusCode == http.StatusOK {

--- a/espresso/environment/attestation_verifier_service_helpers.go
+++ b/espresso/environment/attestation_verifier_service_helpers.go
@@ -144,7 +144,7 @@ func WithAttestationServiceVerifierNitroVerifierAddress(nitroVerifierAddress str
 }
 
 // WithAttestationServiceVerifierNetworkUseDocker configures the
-// Netowrk Use Docker configuration for the Attestation Verifier Service.
+// Network Use Docker configuration for the Attestation Verifier Service.
 func WithAttestationServiceVerifierNetworkUseDocker(networkUseDocker string) AttestationVerifierServiceOption {
 	return func(c *AttestationVerifierServiceConfig) {
 		c.networkUseDocker = networkUseDocker

--- a/espresso/environment/attestation_verifier_service_helpers.go
+++ b/espresso/environment/attestation_verifier_service_helpers.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/espresso"
 	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 )
@@ -272,23 +271,6 @@ func WithAttestationConfigFromENV() AttestationVerifierServiceOption {
 	return WithAttestationServiceVerifierOptions(options...)
 }
 
-// AllowEmptyConfigurationValue is a simple string wrapper that is meant
-// to adhere to the espresso.ConfigurationStringValue interface, that allows
-// for the value to be empty.
-type AllowEmptyConfigurationValue string
-
-var _ espresso.ConfigurationStringValue = AllowEmptyConfigurationValue("")
-
-// Value implements ConfigurationStringValue.
-func (a AllowEmptyConfigurationValue) Value() string {
-	return string(a)
-}
-
-// AllowEmpty implements ConfigurationStringValue.
-func (AllowEmptyConfigurationValue) AllowEmpty() bool {
-	return true
-}
-
 // launchEspressoAttestationVerifierServiceDockerContainer is a StartOption that
 // ensures that the Espresso Attestation Verifier Service is launched in its
 // own docker container.
@@ -391,7 +373,7 @@ func launchEspressoAttestationVerifierServiceDockerContainer(ct *E2eDevnetLaunch
 				AttestationVerifierService: attestationVerifierInfo,
 			}
 
-			c.Espresso.EspressoAttestationService = espresso.ConfigurationValue(attestationURL)
+			c.Espresso.EspressoAttestationService = attestationURL
 			healthCheckURL := attestationURL + "/health"
 			for {
 				select {

--- a/espresso/environment/doc.go
+++ b/espresso/environment/doc.go
@@ -1,0 +1,12 @@
+// Package environment package is a collection of files that assist with the
+// creation, management, and easy configuration of the Espresso chain in
+// conjunction with the Optimism E2E (end-to-end) local testing devnet.
+//
+// This package contains a lot of helper functions, and utilities that allow
+// for the easy setup, with sensible defaults, and the configuration of and
+// `espresso-dev-node`, and an Espresso derived Caffienated node.  This
+// process is predominately automatic, and isolated, with piecemeal parts
+// of the Espresso Chain being launched in a Docker Containera, with support
+// for ports that are automatically mapped to external ports without explicit
+// configuration.
+package environment

--- a/espresso/environment/e2e_helpers.go
+++ b/espresso/environment/e2e_helpers.go
@@ -58,7 +58,7 @@ func L2TxWithOptions(options ...helpers.TxOptsFn) helpers.TxOptsFn {
 func WithSequencerUseFinalized(useFinalized bool) E2eDevnetLauncherOption {
 	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				seqConfig := cfg.Nodes[e2esys.RoleSeq]
 				seqConfig.Driver.SequencerUseFinalized = useFinalized
 			},
@@ -71,7 +71,7 @@ func WithSequencerUseFinalized(useFinalized bool) E2eDevnetLauncherOption {
 func WithNonFinalizedProposals(useNonFinalized bool) E2eDevnetLauncherOption {
 	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.NonFinalizedProposals = useNonFinalized
 			},
 		}
@@ -83,7 +83,7 @@ func WithNonFinalizedProposals(useNonFinalized bool) E2eDevnetLauncherOption {
 func WithL1FinalizedDistance(distance uint64) E2eDevnetLauncherOption {
 	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.L1FinalizedDistance = distance
 			},
 		}
@@ -95,7 +95,7 @@ func WithL1FinalizedDistance(distance uint64) E2eDevnetLauncherOption {
 func WithSequencerWindowSize(size uint64) E2eDevnetLauncherOption {
 	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DeployConfig.SequencerWindowSize = size
 			},
 		}
@@ -110,7 +110,7 @@ func WithSequencerWindowSize(size uint64) E2eDevnetLauncherOption {
 func WithL1BlockTime(blockTime time.Duration) E2eDevnetLauncherOption {
 	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DeployConfig.L1BlockTime = uint64(blockTime / time.Second)
 			},
 		}
@@ -125,7 +125,7 @@ func WithL1BlockTime(blockTime time.Duration) E2eDevnetLauncherOption {
 func WithL2BlockTime(blockTime time.Duration) E2eDevnetLauncherOption {
 	return func(c *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DeployConfig.L2BlockTime = uint64(blockTime / time.Second)
 			},
 		}

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -79,6 +79,12 @@ func appendArg(args *[]string, flagName string, value any) {
 // LaunchBatcherInEnclave is an E2eDevnetLauncherOption that configures the
 // batcher to not launch in the standard e2e devnet, and to launch the batcher
 // externally in an Enclave.
+//
+// Adding this option automatically configures the Espresso Attestation
+// Service Service with its default configuration. This is required to run in
+// an Enclave, as such, it is better to pre-configure the option instead of
+// allowing for the potential of an error to occur due to not including the
+// other Option.
 func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
 	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
@@ -87,6 +93,7 @@ func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
 			},
 			SystemConfigOpt: e2esys.WithAllocType(config.AllocTypeEspressoWithEnclave),
 			StartOptions: []e2esys.StartOption{
+				launchEspressoAttestationVerifierServiceDockerContainer(ct),
 				{
 					Role: "launch-batcher-in-enclave",
 

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -184,7 +184,12 @@ func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
 						for _, url := range c.Espresso.QueryServiceURLs {
 							appendArg(&args, espresso.QueryServiceUrlsFlagName, url)
 						}
-						appendArg(&args, espresso.AttestationServiceFlagName, c.Espresso.EspressoAttestationService.Value())
+						var espressoAttestationService string
+						if value := c.Espresso.EspressoAttestationService; value != nil {
+							espressoAttestationService = value.Value()
+						}
+						appendArg(&args, espresso.AttestationServiceFlagName, espressoAttestationService)
+
 						err := SetupEnclaver(ct.Ctx, sys, args...)
 						if err != nil {
 							panic(fmt.Sprintf("failed to setup enclaver: %v", err))

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -34,9 +34,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const ENCLAVE_INTERMEDIATE_IMAGE_TAG = "op-batcher-enclave:tests"
-const ENCLAVE_IMAGE_TAG = "op-batcher-enclaver:tests"
-const ESPRESSO_ENABLE_ENCLAVE_TESTS = "ESPRESSO_RUN_ENCLAVE_TESTS"
+const (
+	ENCLAVE_INTERMEDIATE_IMAGE_TAG = "op-batcher-enclave:tests"
+	ENCLAVE_IMAGE_TAG              = "op-batcher-enclaver:tests"
+	ESPRESSO_ENABLE_ENCLAVE_TESTS  = "ESPRESSO_RUN_ENCLAVE_TESTS"
+)
 
 // Skips the calling test if `ESPRESSO_ENABLE_ENCLAVE_TESTS` is not set.
 func RunOnlyWithEnclave(t *testing.T) {
@@ -182,7 +184,7 @@ func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
 						for _, url := range c.Espresso.QueryServiceURLs {
 							appendArg(&args, espresso.QueryServiceUrlsFlagName, url)
 						}
-						appendArg(&args, espresso.AttestationServiceFlagName, c.Espresso.EspressoAttestationService)
+						appendArg(&args, espresso.AttestationServiceFlagName, c.Espresso.EspressoAttestationService.Value())
 						err := SetupEnclaver(ct.Ctx, sys, args...)
 						if err != nil {
 							panic(fmt.Sprintf("failed to setup enclaver: %v", err))

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-batcher/bindings"
 	"github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
@@ -75,12 +76,16 @@ func appendArg(args *[]string, flagName string, value any) {
 	}
 }
 
+// LaunchBatcherInEnclave is an E2eDevnetLauncherOption that configures the
+// batcher to not launch in the standard e2e devnet, and to launch the batcher
+// externally in an Enclave.
 func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
 	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: func(cfg *e2esys.SystemConfig) {
+			SystemConfigOption: func(cfg *e2esys.SystemConfig) {
 				cfg.DisableBatcher = true
 			},
+			SystemConfigOpt: e2esys.WithAllocType(config.AllocTypeEspressoWithEnclave),
 			StartOptions: []e2esys.StartOption{
 				{
 					Role: "launch-batcher-in-enclave",

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -189,11 +189,7 @@ func LaunchBatcherInEnclave() E2eDevnetLauncherOption {
 						for _, url := range c.Espresso.QueryServiceURLs {
 							appendArg(&args, espresso.QueryServiceUrlsFlagName, url)
 						}
-						var espressoAttestationService string
-						if value := c.Espresso.EspressoAttestationService; value != nil {
-							espressoAttestationService = value.Value()
-						}
-						appendArg(&args, espresso.AttestationServiceFlagName, espressoAttestationService)
+						appendArg(&args, espresso.AttestationServiceFlagName, c.Espresso.EspressoAttestationService)
 
 						err := SetupEnclaver(ct.Ctx, sys, args...)
 						if err != nil {

--- a/espresso/environment/espresso_dev_net_launcher.go
+++ b/espresso/environment/espresso_dev_net_launcher.go
@@ -11,7 +11,6 @@ import (
 // EspressoE2eDevnetLauncher is an interface for launching an E2E devnet with Espresso, and
 // configuring it to run in a desired manner.
 type EspressoE2eDevnetLauncher interface {
-
 	// StartE2eDevnet will launch the devnet with the provided options. The returned system will be
 	// a fully configured e2e system with the configured options.
 	StartE2eDevnet(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error)
@@ -42,17 +41,40 @@ type E2eDevnetLauncherOption func(
 	ctx *E2eDevnetLauncherContext,
 ) E2eSystemOption
 
+// SysConfigBuilder is a function that is used to construct the Initial System
+// Config Options
+type SysConfigBuilder func(*testing.T, ...e2esys.SystemConfigOpt) e2esys.SystemConfig
+
 // E2eSystemOption is a struct that contains the options for the
 // e2e system that is being launched. It contains the GethOptions and
 // any relevant StartOptions that may be needed for the system.
 type E2eSystemOption struct {
-	SysConfigOption func(*e2esys.SystemConfig)
+	// SystemConfigOption is a function that modifies the SystemConfig.
+	// This occurs specifically after initialization, but before startup.
+	//
+	// This is separate from the SystemConfigOpt, which only happens
+	// at intiial creation time.
+	SystemConfigOption func(*e2esys.SystemConfig)
+
+	// SystemConfigOpt is a Configuration Options for the creation of
+	// the intiial SystemConfig.
+	//
+	// This is necessary, as the initialization has some additional triggered
+	// side-effects that will not occur if not encountered otherwise.
+	SystemConfigOpt e2esys.SystemConfigOpt
 
 	// The GethOptions to pass to the Geth Node.
 	GethOptions map[string][]geth.GethOption
 
 	// Any relevant StartOptions to pass to the e2e system.
 	StartOptions []e2esys.StartOption
+
+	// SysConfigBuilder allows for the overidding of the initially constructed
+	// System Configuration Behavior.
+	//
+	// This is only necessary if some other systems are launched as a
+	// consequence, suche as those with the Dispute Game setup.
+	SysConfigBuilder
 }
 
 // EspressoDevNode is an interface that wraps the Espresso Dev Node

--- a/espresso/environment/espresso_dev_node_test.go
+++ b/espresso/environment/espresso_dev_node_test.go
@@ -107,7 +107,6 @@ func TestE2eDevnetWithEspressoSimpleTransactions(t *testing.T) {
 
 	// Submit a Transaction on the L2 Sequencer node, to a Burn Address
 	env.RunSimpleL2Burn(ctx, t, system)
-
 }
 
 // TestE2eDevnetWithEspressoAndAltDaSimpleTransactions launches the e2e Dev Net with the Espresso
@@ -117,7 +116,6 @@ func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 	defer cancel()
 
 	launcher := new(env.EspressoDevNodeLauncherDocker)
-	launcher.AltDa = true
 
 	// Start a temporary EigenDA Docker instance for this test
 	eigenda, err := env.StartEigenDA(ctx)
@@ -127,7 +125,7 @@ func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 	// Stopped when the test exits
 	defer env.StopDockerContainer(eigenda.ContainerID)
 
-	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t)
+	system, espressoDevNode, err := launcher.StartE2eDevnet(ctx, t, env.WithAltDa())
 	if have, want := err, error(nil); have != want {
 		t.Fatalf("failed to start dev environment with espresso dev node:\nhave:\n\t\"%v\"\nwant:\n\t\"%v\"\n", have, want)
 	}
@@ -140,7 +138,6 @@ func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 
 	// Submit a Transaction on the L2 Sequencer node, to a Burn Address
 	env.RunSimpleL2Burn(ctx, t, system)
-
 }
 
 // TestE2eDevnetWithoutEspressoSimpleTransactions launches the e2e Dev Net

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -15,7 +15,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
+
 	"strconv"
 	"testing"
 	"time"
@@ -351,7 +351,7 @@ func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetWithFaultDisputeSysConfig(ct
 func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetStartOptions(originalCtx context.Context, t *testing.T, sysConfig *e2esys.SystemConfig, options ...E2eDevnetLauncherOption) ([]e2esys.StartOption, *E2eDevnetLauncherContext) {
 	initialOptions := []E2eDevnetLauncherOption{
 		allowHostDockerInternalVirtualHost(),
-		launchEspressoDevNodeAndAttestationServiceDocker(),
+		launchEspressoDevNodeDocker(),
 	}
 
 	if l.EnclaveBatcher {
@@ -827,11 +827,10 @@ func ensureHardCodedPortsAreMappedFromTheirOriginalValues(containerInfo *DockerC
 	}
 }
 
-// launchEspressoDevNodeAndAttestationVerifierZKStartOption is E2eDevnetLauncherOption that launches the
+// launchEspressoDevNodeStartOption is E2eDevnetLauncherOption that launches the
 // Espresso Dev Node within a Docker container.  It also ensures that the
 // Espresso Dev Node is actively producing blocks before returning.
-// Additionally, it launches the Attestation Verifier ZK server in a Docker container.
-func launchEspressoDevNodeAndAttestationVerifierZKStartOption(ct *E2eDevnetLauncherContext) e2esys.StartOption {
+func launchEspressoDevNodeStartOption(ct *E2eDevnetLauncherContext) e2esys.StartOption {
 	return e2esys.StartOption{
 		Role: "launch-espresso-dev-node",
 		BatcherMod: func(c *batcher.CLIConfig, sys *e2esys.System) {
@@ -894,163 +893,18 @@ func launchEspressoDevNodeAndAttestationVerifierZKStartOption(ct *E2eDevnetLaunc
 			c.Espresso.QueryServiceURLs = espressoDevNode.espressoUrls
 			c.LogConfig.Level = slog.LevelDebug
 			c.Espresso.LightClientAddr = common.HexToAddress(ESPRESSO_LIGHT_CLIENT_ADDRESS)
-
-			// Now launch the attestation verifier zk server
-			launchEspressoAttestationVerifierService(ct, c)
 		},
 	}
 }
 
-// launchEspressoAttestationVerifierService launches the attestation verifier zk server
-// in a Docker container and configures the batcher CLIConfig to use it.
-func launchEspressoAttestationVerifierService(ct *E2eDevnetLauncherContext, c *batcher.CLIConfig) {
-	// Now we need to launch the attestation verifier zk server
-	fmt.Println("Starting attestation verifier zk server...")
-
-	espressoAttestationVerifierNetworkRPCURL := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_RPC_URL")
-	if espressoAttestationVerifierNetworkRPCURL == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_RPC_URL environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierSp1Prover := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_SP1_PROVER")
-	if espressoAttestationVerifierSp1Prover == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_SP1_PROVER environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierNitroVerifierAddress := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NITRO_VERIFIER_ADDRESS")
-	if espressoAttestationVerifierNitroVerifierAddress == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_NITRO_VERIFIER_ADDRESS environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierUseDocker := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_USE_DOCKER")
-	if espressoAttestationVerifierUseDocker == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_USE_DOCKER environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierSkipTimeValidityCheck := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_SKIP_TIME_VALIDITY_CHECK")
-	if espressoAttestationVerifierSkipTimeValidityCheck == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_SKIP_TIME_VALIDITY_CHECK environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierRustLog := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_RUST_LOG")
-	if espressoAttestationVerifierRustLog == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_RUST_LOG environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierNetworkPrivateKey := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_NETWORK_PRIVATE_KEY")
-	if espressoAttestationVerifierNetworkPrivateKey == "" {
-		ct.Error = fmt.Errorf("networkPrivateKey environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierRPCUrl := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_RPC_URL")
-	if espressoAttestationVerifierRPCUrl == "" {
-		ct.Error = fmt.Errorf("RPC_URL environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierHost := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_HOST")
-	if espressoAttestationVerifierHost == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_HOST environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierPort := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_PORT")
-	if espressoAttestationVerifierPort == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_PORT environment variable is not set")
-		return
-	}
-
-	espressoAttestationVerifierDockerImage := os.Getenv("ESPRESSO_ATTESTATION_VERIFIER_DOCKER_IMAGE")
-	if espressoAttestationVerifierDockerImage == "" {
-		ct.Error = fmt.Errorf("ESPRESSO_ATTESTATION_VERIFIER_DOCKER_IMAGE environment variable is not set")
-		return
-	}
-
-	dockerConfig := DockerContainerConfig{
-		Image:   espressoAttestationVerifierDockerImage,
-		Network: determineDockerNetworkMode(),
-		Ports: []string{
-			espressoAttestationVerifierPort,
-		},
-		Name: "attestation-verifier-zk",
-		Environment: map[string]string{
-			"NETWORK_RPC_URL":          espressoAttestationVerifierNetworkRPCURL,
-			"SP1_PROVER":               espressoAttestationVerifierSp1Prover,
-			"NITRO_VERIFIER_ADDRESS":   espressoAttestationVerifierNitroVerifierAddress,
-			"USE_DOCKER":               espressoAttestationVerifierUseDocker,
-			"SKIP_TIME_VALIDITY_CHECK": espressoAttestationVerifierSkipTimeValidityCheck,
-			"RUST_LOG":                 espressoAttestationVerifierRustLog,
-			"NETWORK_PRIVATE_KEY":      espressoAttestationVerifierNetworkPrivateKey,
-			"RPC_URL":                  espressoAttestationVerifierRPCUrl,
-			"HOST":                     espressoAttestationVerifierHost,
-			"PORT":                     espressoAttestationVerifierPort,
-		},
-	}
-	containerCli := new(DockerCli)
-
-	attestationVerifierInfo, err := containerCli.LaunchContainer(ct.Ctx, dockerConfig)
-	if err != nil {
-		ct.Error = FailedToLaunchDockerContainer{Cause: err}
-		return
-	}
-
-	// Get the actual mapped port
-	ports := attestationVerifierInfo.PortMap[espressoAttestationVerifierPort]
-	if len(ports) == 0 {
-		ct.Error = fmt.Errorf("no port mapping found for attestation verifier")
-		return
-	}
-
-	healthCheckCtx, cancel := context.WithTimeout(ct.Ctx, 60*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-	attestationHostPort, err := getContainerRemappedHostPort(ports[0])
-	if err != nil {
-		ct.Error = err
-		return
-	}
-
-	// Use the actual host:port for health check
-	attestationURL := "http://" + attestationHostPort
-
-	c.Espresso.EspressoAttestationService = attestationURL
-
-	for {
-		select {
-		case <-healthCheckCtx.Done():
-			ct.Error = fmt.Errorf("attestation verifier did not become healthy: %w", healthCheckCtx.Err())
-			return
-		case <-ticker.C:
-			resp, err := http.Get(attestationURL + "/health")
-			if err == nil && resp.StatusCode == http.StatusOK {
-				resp.Body.Close()
-				goto healthy
-			}
-			if resp != nil {
-				resp.Body.Close()
-			}
-		}
-	}
-healthy:
-}
-
-// launchEspressoDevNodeAndAttestationVerifierZKStartOption is E2eDevnetLauncherOption that launches the
+// launchEspressoDevNodeDocker is E2eDevnetLauncherOption that launches the
 // Espresso Dev Node within a Docker container.  It also ensures that the
 // Espresso Dev Node is actively producing blocks before returning.
-func launchEspressoDevNodeAndAttestationServiceDocker() E2eDevnetLauncherOption {
+func launchEspressoDevNodeDocker() E2eDevnetLauncherOption {
 	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
 			StartOptions: []e2esys.StartOption{
-				launchEspressoDevNodeAndAttestationVerifierZKStartOption(ct),
+				launchEspressoDevNodeStartOption(ct),
 			},
 		}
 	}

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -888,6 +888,7 @@ func launchEspressoDevNodeStartOption(ct *E2eDevnetLauncherContext) e2esys.Start
 			c.Espresso.QueryServiceURLs = espressoDevNode.espressoUrls
 			c.LogConfig.Level = slog.LevelDebug
 			c.Espresso.LightClientAddr = common.HexToAddress(ESPRESSO_LIGHT_CLIENT_ADDRESS)
+			c.Espresso.EspressoAttestationService = AllowEmptyConfigurationValue("")
 		},
 	}
 }

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -146,12 +146,7 @@ func WaitForEspressoBlockHeightToBePositive(ctx context.Context, url string) err
 
 // EspressoDevNodeLauncherDocker is an implementation of EspressoDevNodeLauncher
 // that uses Docker to launch the Espresso Dev Node
-type EspressoDevNodeLauncherDocker struct {
-	// Whether to run batcher in enclave.
-	EnclaveBatcher bool
-	// Whether to enable AltDa
-	AltDa bool
-}
+type EspressoDevNodeLauncherDocker struct{}
 
 var _ EspressoE2eDevnetLauncher = (*EspressoDevNodeLauncherDocker)(nil)
 
@@ -256,28 +251,30 @@ func (e EspressoDevNodeContainerInfo) Stop() error {
 // is meant to be.
 var ErrUnableToDetermineEspressoDevNodeSequencerHost = errors.New("unable to determine the host for the espresso-dev-node sequencer api")
 
+// defaultSystemConfigBuilder is the default SystemConfigBuilder utilized by
+// the GetE2eDevnetSysConfig method.
+func defaultSystemConfigBuilder(t *testing.T, options ...e2esys.SystemConfigOpt) e2esys.SystemConfig {
+	return e2esys.DefaultSystemConfig(t, options...)
+}
+
 // GetE2eDevnetSysConfig returns a configuration for an E2E devnet.
-func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetSysConfig(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) e2esys.SystemConfig {
-	var allocOpt e2esys.SystemConfigOpt
-	if l.EnclaveBatcher {
-		allocOpt = e2esys.WithAllocType(config.AllocTypeEspressoWithEnclave)
-	} else {
-		allocOpt = e2esys.WithAllocType(config.AllocTypeEspressoWithoutEnclave)
+func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetSysConfig(ctx context.Context, t *testing.T, options ...E2eSystemOption) e2esys.SystemConfig {
+	systemConfigsOpts := []e2esys.SystemConfigOpt{
+		e2esys.WithAllocType(config.AllocTypeEspressoWithoutEnclave),
 	}
 
-	sysConfig := e2esys.DefaultSystemConfig(t, allocOpt)
+	sysConfigBuilder := defaultSystemConfigBuilder
+	for _, opt := range options {
+		if sysConfigOption := opt.SystemConfigOpt; sysConfigOption != nil {
+			systemConfigsOpts = append(systemConfigsOpts, sysConfigOption)
+		}
 
-	if l.AltDa {
-		sysConfig.DeployConfig.UseAltDA = true
-		sysConfig.DeployConfig.DACommitmentType = "KeccakCommitment"
-		sysConfig.DeployConfig.DAChallengeWindow = 16
-		sysConfig.DeployConfig.DAResolveWindow = 16
-		sysConfig.DeployConfig.DABondSize = 1000000
-		sysConfig.DeployConfig.DAResolverRefundPercentage = 0
-		sysConfig.BatcherMaxPendingTransactions = 0
-		sysConfig.BatcherBatchType = 0
-		sysConfig.DataAvailabilityType = flags.CalldataType
+		if builder := opt.SysConfigBuilder; builder != nil {
+			sysConfigBuilder = builder
+		}
 	}
+
+	sysConfig := sysConfigBuilder(t, systemConfigsOpts...)
 
 	// Set a short L1 block time and finalized distance to make tests faster and reach finality sooner
 	sysConfig.DeployConfig.L1BlockTime = 2
@@ -299,70 +296,56 @@ func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetSysConfig(ctx context.Contex
 		sysConfig.L1Allocs[address] = account.State
 	}
 
+	for _, opt := range options {
+		if sysConfigOption := opt.SystemConfigOption; sysConfigOption != nil {
+			sysConfigOption(&sysConfig)
+		}
+	}
+
 	return sysConfig
 }
 
-// GetE2eDevnetWithFaultDisputeSysConfig returns a configuration for an E2E devnet with a Fault
-// Dispute System.
-func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetWithFaultDisputeSysConfig(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) e2esys.SystemConfig {
-	var allocOpt e2esys.SystemConfigOpt
-	if l.EnclaveBatcher {
-		allocOpt = e2esys.WithAllocType(config.AllocTypeEspressoWithEnclave)
-	} else {
-		allocOpt = e2esys.WithAllocType(config.AllocTypeEspressoWithoutEnclave)
+// faultDisputeSystemConfigBuilder id a SystemConfigBuilder that configures
+// the system for use with the Fault Dispute System.
+func faultDisputeSystemConfigBuilder(t *testing.T, options ...e2esys.SystemConfigOpt) e2esys.SystemConfig {
+	return faultproofs.GetFaultDisputeSystemConfigForEspresso(t, options)
+}
+
+// WithFaultDisputeSystem will modify the default SysConfigBuilder utilized
+// to be one that configures the FaultDisputeSsytem for Espresso.
+func WithFaultDisputeSystem() E2eDevnetLauncherOption {
+	return func(launcherCtx *E2eDevnetLauncherContext) E2eSystemOption {
+		return E2eSystemOption{
+			SysConfigBuilder: faultDisputeSystemConfigBuilder,
+		}
 	}
+}
 
-	// Get a Fault Dispute System configuration with Espresso Dev Node allocation
-	sysConfig := faultproofs.GetFaultDisputeSystemConfigForEspresso(t, []e2esys.SystemConfigOpt{allocOpt})
-
-	if l.AltDa {
-		sysConfig.DeployConfig.UseAltDA = true
-		sysConfig.DeployConfig.DACommitmentType = "KeccakCommitment"
-		sysConfig.DeployConfig.DAChallengeWindow = 16
-		sysConfig.DeployConfig.DAResolveWindow = 16
-		sysConfig.DeployConfig.DABondSize = 1000000
-		sysConfig.DeployConfig.DAResolverRefundPercentage = 0
-		sysConfig.BatcherMaxPendingTransactions = 0
-		sysConfig.BatcherBatchType = 0
-		sysConfig.DataAvailabilityType = flags.CalldataType
+// WithAltDa is an E2eDevnetLauncherOption that adjusts the SystemConfig
+// to be configured for use as a Alt Da.
+func WithAltDa() E2eDevnetLauncherOption {
+	return func(_ *E2eDevnetLauncherContext) E2eSystemOption {
+		return E2eSystemOption{
+			SystemConfigOption: func(sysConfig *e2esys.SystemConfig) {
+				sysConfig.DeployConfig.UseAltDA = true
+				sysConfig.DeployConfig.DACommitmentType = "KeccakCommitment"
+				sysConfig.DeployConfig.DAChallengeWindow = 16
+				sysConfig.DeployConfig.DAResolveWindow = 16
+				sysConfig.DeployConfig.DABondSize = 1000000
+				sysConfig.DeployConfig.DAResolverRefundPercentage = 0
+				sysConfig.BatcherMaxPendingTransactions = 0
+				sysConfig.BatcherBatchType = 0
+				sysConfig.DataAvailabilityType = flags.CalldataType
+			},
+		}
 	}
-
-	// Set a short L1 block time and finalized distance to make tests faster and reach finality sooner
-	sysConfig.DeployConfig.L1BlockTime = 2
-
-	sysConfig.DeployConfig.DeployCeloContracts = true
-
-	// Ensure that we fund the dev accounts
-	sysConfig.DeployConfig.FundDevAccounts = true
-
-	espressoPremine := new(big.Int).Mul(new(big.Int).SetUint64(1_000_000), new(big.Int).SetUint64(params.Ether))
-	sysConfig.L1Allocs[ESPRESSO_CONTRACT_ACCOUNT] = types.Account{
-		Nonce:   100000,          // Set the nonce to avoid collisions with predeployed contracts
-		Balance: espressoPremine, // Pre-fund Espresso deployer acount with 1M Ether
-	}
-
-	// Set up the L1Allocs in the system config
-	for address, account := range ESPRESSO_ALLOCS {
-		sysConfig.L1Allocs[address] = account.State
-	}
-
-	return sysConfig
 }
 
 // GetE2eDevnetStartOptions returns the start options for the E2E devnet.
-func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetStartOptions(originalCtx context.Context, t *testing.T, sysConfig *e2esys.SystemConfig, options ...E2eDevnetLauncherOption) ([]e2esys.StartOption, *E2eDevnetLauncherContext) {
+func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetStartOptions(originalCtx context.Context, t *testing.T, launchContext *E2eDevnetLauncherContext, options ...E2eDevnetLauncherOption) []e2esys.StartOption {
 	initialOptions := []E2eDevnetLauncherOption{
 		allowHostDockerInternalVirtualHost(),
 		launchEspressoDevNodeDocker(),
-	}
-
-	if l.EnclaveBatcher {
-		initialOptions = append(initialOptions, LaunchBatcherInEnclave())
-	}
-
-	launchContext := E2eDevnetLauncherContext{
-		Ctx:       originalCtx,
-		SystemCfg: sysConfig,
 	}
 
 	allOptions := append(initialOptions, options...)
@@ -370,73 +353,47 @@ func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetStartOptions(originalCtx con
 	startOptions := []e2esys.StartOption{}
 
 	for _, opt := range allOptions {
-		options := opt(&launchContext)
+		options := opt(launchContext)
 
 		if gethOption := options.GethOptions; gethOption != nil {
 			for k, v := range gethOption {
-				sysConfig.GethOptions[k] = append(sysConfig.GethOptions[k], v...)
+				launchContext.SystemCfg.GethOptions[k] = append(launchContext.SystemCfg.GethOptions[k], v...)
 			}
 		}
 
 		if startOption := options.StartOptions; startOption != nil {
 			startOptions = append(startOptions, startOption...)
 		}
-
-		if sysConfigOption := options.SysConfigOption; sysConfigOption != nil {
-			sysConfigOption(sysConfig)
-		}
 	}
 
-	return startOptions, &launchContext
+	return startOptions
+}
+
+func expandLauncherOptionsToSystemOptions(launchContext *E2eDevnetLauncherContext, options []E2eDevnetLauncherOption) []E2eSystemOption {
+	e2eSystemOption := make([]E2eSystemOption, 0, len(options))
+	for _, opt := range options {
+		e2eSystemOption = append(e2eSystemOption, opt(launchContext))
+	}
+
+	return e2eSystemOption
 }
 
 func (l *EspressoDevNodeLauncherDocker) StartE2eDevnet(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
-	sysConfig := l.GetE2eDevnetSysConfig(ctx, t, options...)
+	launchContext := E2eDevnetLauncherContext{
+		Ctx:       ctx,
+		SystemCfg: nil,
+	}
 
+	e2eSystemOption := expandLauncherOptionsToSystemOptions(&launchContext, options)
+
+	sysConfig := l.GetE2eDevnetSysConfig(ctx, t, e2eSystemOption...)
 	originalCtx := ctx
-	startOptions, launchContext := l.GetE2eDevnetStartOptions(originalCtx, t, &sysConfig, options...)
+	launchContext.SystemCfg = &sysConfig
+
+	startOptions := l.GetE2eDevnetStartOptions(originalCtx, t, &launchContext, options...)
 
 	// We want to run the espresso-dev-node.  But we need it to be able to
 	// access the L1 node.
-
-	system, err := sysConfig.Start(
-		t,
-
-		startOptions...,
-	)
-	if err != nil {
-		if system != nil {
-			// We don't want the system running in a partial / incomplete
-			// state. So we'll tell it to stop here, just in case.
-			system.Close()
-		}
-
-		return system, nil, err
-	}
-
-	// Auto System Cleanup tied to the passed in context.
-	{
-		// We want to ensure that the lifecycle of the system node is tied to
-		// the context we were given, just like the espresso-dev-node.  So if
-		// the context is canceled, or otherwise closed, it will automatically
-		// clean up the system.
-		go (func(ctx context.Context) {
-			<-ctx.Done()
-
-			// The system is guaranteed to not be null here.
-			system.Close()
-		})(originalCtx)
-	}
-
-	return system, launchContext.EspressoDevNode, launchContext.Error
-}
-
-// StartE2eDevnetWithFaultDisputeSystem starts a Fault Dispute System with an Espresso Dev Node
-func (l *EspressoDevNodeLauncherDocker) StartE2eDevnetWithFaultDisputeSystem(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
-	sysConfig := l.GetE2eDevnetWithFaultDisputeSysConfig(ctx, t, options...)
-
-	originalCtx := ctx
-	startOptions, launchContext := l.GetE2eDevnetStartOptions(originalCtx, t, &sysConfig, options...)
 
 	system, err := sysConfig.Start(
 		t,
@@ -616,7 +573,7 @@ func SetEspressoUrls(numGood int, numBad int, badServerUrl string) E2eDevnetLaun
 func Config(fn func(*e2esys.SystemConfig)) E2eDevnetLauncherOption {
 	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
 		return E2eSystemOption{
-			SysConfigOption: fn,
+			SystemConfigOption: fn,
 		}
 	}
 }

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-
 	"strconv"
 	"testing"
 	"time"
@@ -71,13 +70,17 @@ const ESPRESSO_TESTING_BATCHER_KEY = "0xfad9c8855b740a0b7ed4c221dbad0f33a83a49ca
 // This is address that corresponds to the menmonic we pass to the espresso-dev-node
 var ESPRESSO_CONTRACT_ACCOUNT = common.HexToAddress("0x8943545177806ed17b9f23f0a21ee5948ecaa776")
 
-const ESPRESSO_BUILDER_PORT = "31003"
-const ESPRESSO_SEQUENCER_API_PORT = "24000"
-const ESPRESSO_DEV_NODE_PORT = "24002"
+const (
+	ESPRESSO_BUILDER_PORT       = "31003"
+	ESPRESSO_SEQUENCER_API_PORT = "24000"
+	ESPRESSO_DEV_NODE_PORT      = "24002"
+)
 
 // EigenDA consstants
-const EIGENDA_DOCKER_PORT = "3100"
-const EIGENDA_DOCKER_IMAGE = "ghcr.io/layr-labs/eigenda-proxy:2.2.1"
+const (
+	EIGENDA_DOCKER_PORT  = "3100"
+	EIGENDA_DOCKER_IMAGE = "ghcr.io/layr-labs/eigenda-proxy:2.2.1"
+)
 
 // ErrEspressoBlockHeightDidNotIncrease is a sentinel error that occurs when
 // the Espresso Block Height does not increase within the alloted context
@@ -255,7 +258,6 @@ var ErrUnableToDetermineEspressoDevNodeSequencerHost = errors.New("unable to det
 
 // GetE2eDevnetSysConfig returns a configuration for an E2E devnet.
 func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetSysConfig(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) e2esys.SystemConfig {
-
 	var allocOpt e2esys.SystemConfigOpt
 	if l.EnclaveBatcher {
 		allocOpt = e2esys.WithAllocType(config.AllocTypeEspressoWithEnclave)
@@ -292,7 +294,7 @@ func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetSysConfig(ctx context.Contex
 		Balance: millionEthers, // Pre-fund Espresso deployer acount with 1M Ether
 	}
 
-	//Set up the L1Allocs in the system config
+	// Set up the L1Allocs in the system config
 	for address, account := range ESPRESSO_ALLOCS {
 		sysConfig.L1Allocs[address] = account.State
 	}
@@ -339,7 +341,7 @@ func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetWithFaultDisputeSysConfig(ct
 		Balance: espressoPremine, // Pre-fund Espresso deployer acount with 1M Ether
 	}
 
-	//Set up the L1Allocs in the system config
+	// Set up the L1Allocs in the system config
 	for address, account := range ESPRESSO_ALLOCS {
 		sysConfig.L1Allocs[address] = account.State
 	}
@@ -389,7 +391,6 @@ func (l *EspressoDevNodeLauncherDocker) GetE2eDevnetStartOptions(originalCtx con
 }
 
 func (l *EspressoDevNodeLauncherDocker) StartE2eDevnet(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
-
 	sysConfig := l.GetE2eDevnetSysConfig(ctx, t, options...)
 
 	originalCtx := ctx
@@ -403,7 +404,6 @@ func (l *EspressoDevNodeLauncherDocker) StartE2eDevnet(ctx context.Context, t *t
 
 		startOptions...,
 	)
-
 	if err != nil {
 		if system != nil {
 			// We don't want the system running in a partial / incomplete
@@ -433,7 +433,6 @@ func (l *EspressoDevNodeLauncherDocker) StartE2eDevnet(ctx context.Context, t *t
 
 // StartE2eDevnetWithFaultDisputeSystem starts a Fault Dispute System with an Espresso Dev Node
 func (l *EspressoDevNodeLauncherDocker) StartE2eDevnetWithFaultDisputeSystem(ctx context.Context, t *testing.T, options ...E2eDevnetLauncherOption) (*e2esys.System, EspressoDevNode, error) {
-
 	sysConfig := l.GetE2eDevnetWithFaultDisputeSysConfig(ctx, t, options...)
 
 	originalCtx := ctx
@@ -444,7 +443,6 @@ func (l *EspressoDevNodeLauncherDocker) StartE2eDevnetWithFaultDisputeSystem(ctx
 
 		startOptions...,
 	)
-
 	if err != nil {
 		if system != nil {
 			// We don't want the system running in a partial / incomplete
@@ -593,12 +591,10 @@ func GetBatcherConfig(c *batcher.CLIConfig) E2eDevnetLauncherOption {
 // This function is introduced for testing purposes. It allows to check the enforcement of the majority rule (Test 12)
 func SetEspressoUrls(numGood int, numBad int, badServerUrl string) E2eDevnetLauncherOption {
 	return func(ct *E2eDevnetLauncherContext) E2eSystemOption {
-
 		return E2eSystemOption{
 			StartOptions: []e2esys.StartOption{
 				{
 					BatcherMod: func(c *batcher.CLIConfig, sys *e2esys.System) {
-
 						goodUrl := c.Espresso.QueryServiceURLs[0]
 						var urls []string
 
@@ -863,7 +859,6 @@ func launchEspressoDevNodeStartOption(ct *E2eDevnetLauncherContext) e2esys.Start
 			containerCli := new(DockerCli)
 
 			espressoDevNodeContainerInfo, err := containerCli.LaunchContainer(ct.Ctx, dockerConfig)
-
 			if err != nil {
 				ct.Error = FailedToLaunchDockerContainer{Cause: err}
 				return
@@ -983,7 +978,6 @@ func Stop(t *testing.T, toStop any, options ...StopOption) {
 
 // Waits for an Espresso transaction to be confirmed using its hash.
 func WaitForEspressoTx(ctx context.Context, txHash *espressoCommon.TaggedBase64, espressoClient *espressoClient.MultipleNodesClient) error {
-
 	const transactionFetchTimeout = 4 * time.Second
 	const transactionFetchInterval = 100 * time.Millisecond
 

--- a/espresso/environment/optitmism_espresso_test_helpers.go
+++ b/espresso/environment/optitmism_espresso_test_helpers.go
@@ -845,7 +845,7 @@ func launchEspressoDevNodeStartOption(ct *E2eDevnetLauncherContext) e2esys.Start
 			c.Espresso.QueryServiceURLs = espressoDevNode.espressoUrls
 			c.LogConfig.Level = slog.LevelDebug
 			c.Espresso.LightClientAddr = common.HexToAddress(ESPRESSO_LIGHT_CLIENT_ADDRESS)
-			c.Espresso.EspressoAttestationService = AllowEmptyConfigurationValue("")
+			c.Espresso.AllowEmptyAttestationService()
 		},
 	}
 }

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -967,6 +967,11 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 		return nil
 	}
 
+	if l.Config.EspressoAttestationService == "" {
+		l.Log.Warn("EspressoAttestationServices is not set, skipping registration")
+		return nil
+	}
+
 	l.Log.Info("Batch authenticator address", "value", l.RollupConfig.BatchAuthenticatorAddress)
 	code, err := l.L1Client.CodeAt(ctx, l.RollupConfig.BatchAuthenticatorAddress, nil)
 	if err != nil {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -964,7 +964,7 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 		return nil
 	}
 
-	if l.Config.EspressoAttestationService == nil || l.Config.EspressoAttestationService.AllowEmpty() && l.Config.EspressoAttestationService.Value() == "" {
+	if l.Config.EspressoAttestationService == "" {
 		l.Log.Warn("EspressoAttestationServices is not set, skipping registration")
 		return nil
 	}
@@ -1023,7 +1023,7 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 }
 
 func (l *BatchSubmitter) GenerateZKProof(ctx context.Context, attestationBytes []byte) (*EspressoOnchainProof, error) {
-	attestationServiceURL := strings.TrimSuffix(l.Config.EspressoAttestationService.Value(), "/")
+	attestationServiceURL := strings.TrimSuffix(l.Config.EspressoAttestationService, "/")
 	url := attestationServiceURL + "/generate_proof"
 	request, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(attestationBytes))
 	if err != nil {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -2,18 +2,17 @@ package batcher
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"strings"
-	"time"
-
-	"context"
-	"math/big"
 	"sync"
+	"time"
 
 	espressoClient "github.com/EspressoSystems/espresso-network/sdks/go/client"
 	tagged_base64 "github.com/EspressoSystems/espresso-network/sdks/go/tagged-base64"
@@ -184,7 +183,6 @@ func NewEspressoTransactionSubmitter(options ...EspressoTransactionSubmitterOpti
 		verifyReceiptWorkerQueue: make(chan chan espressoVerifyReceiptJobAttempt),
 		espresso:                 config.EspressoClient,
 	}
-
 }
 
 // SubmitTransaction will submit a transaction to the Job queue.
@@ -907,7 +905,7 @@ func (l *BatchSubmitter) espressoBatchQueueingLoop(ctx context.Context, wg *sync
 	defer ticker.Stop()
 	defer wg.Done()
 
-	var loader = BlockLoader{
+	loader := BlockLoader{
 		batcher: l,
 	}
 
@@ -923,7 +921,6 @@ func (l *BatchSubmitter) espressoBatchQueueingLoop(ctx context.Context, wg *sync
 		select {
 		case <-ticker.C:
 			newSyncStatus, err := l.getSyncStatus(ctx)
-
 			if err != nil {
 				l.Log.Error("Couldn't get sync status", "error", err)
 				continue
@@ -967,7 +964,7 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 		return nil
 	}
 
-	if l.Config.EspressoAttestationService == "" {
+	if l.Config.EspressoAttestationService == nil || l.Config.EspressoAttestationService.AllowEmpty() && l.Config.EspressoAttestationService.Value() == "" {
 		l.Log.Warn("EspressoAttestationServices is not set, skipping registration")
 		return nil
 	}
@@ -1026,7 +1023,7 @@ func (l *BatchSubmitter) registerBatcher(ctx context.Context) error {
 }
 
 func (l *BatchSubmitter) GenerateZKProof(ctx context.Context, attestationBytes []byte) (*EspressoOnchainProof, error) {
-	attestationServiceURL := strings.TrimSuffix(l.Config.EspressoAttestationService, "/")
+	attestationServiceURL := strings.TrimSuffix(l.Config.EspressoAttestationService.Value(), "/")
 	url := attestationServiceURL + "/generate_proof"
 	request, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(attestationBytes))
 	if err != nil {
@@ -1041,7 +1038,9 @@ func (l *BatchSubmitter) GenerateZKProof(ctx context.Context, attestationBytes [
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer (func() {
+		_ = res.Body.Close()
+	})()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("received non-200 response: %d", res.StatusCode)

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -42,7 +42,7 @@ type BatcherConfig struct {
 	NetworkTimeout             time.Duration
 	PollInterval               time.Duration
 	EspressoPollInterval       time.Duration
-	EspressoAttestationService string
+	EspressoAttestationService espresso.ConfigurationStringValue
 	MaxPendingTransactions     uint64
 
 	// UseAltDA is true if the rollup config has a DA challenge address so the batcher

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -42,7 +42,7 @@ type BatcherConfig struct {
 	NetworkTimeout             time.Duration
 	PollInterval               time.Duration
 	EspressoPollInterval       time.Duration
-	EspressoAttestationService espresso.ConfigurationStringValue
+	EspressoAttestationService string
 	MaxPendingTransactions     uint64
 
 	// UseAltDA is true if the rollup config has a DA challenge address so the batcher


### PR DESCRIPTION
<!-- Closes #<ISSUE_NUMBER> -->
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Makes the Attestation Verifier Service opt-in for testing instead of required.  It can be added as an option for tests that require it.  When it is enabled for the Espresso E2E tests, the configuration has been provided a set of defaults that can be overridden as needed.  Additionally, in order to preserve existing behavior, if the environment variables are set to non-empty values, they will be utilized instead of the defaults (unless they are explicitly replaced with an option).

> NOTE: This also makes the Batcher no longer require the verifier URL to be populated.  If it is not set, the registration will not occur.  A `WARN` log is performed in this case in order to alert the user about the issue.  A different approach may be desired here so that the E2E tests can effectively disable this requirement, while a normal configuration would still require it to be populated.

<!-- ### This PR does not: -->
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212672289387602