### PR TITLE
Enable batcher address update and fix tests after upgradability changes

### DIFF
--- a/espresso/devnet-tests/key_rotation_test.go
+++ b/espresso/devnet-tests/key_rotation_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/bindings"
+	e2ebindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +51,27 @@ func TestChangeBatchInboxOwner(t *testing.T) {
 	bobAddress := d.secrets.Addresses().Bob
 	require.NotEqual(t, currentOwner, bobAddress)
 
+	// Get the ProxyAdmin address from the BatchAuthenticator proxy
+	proxyContract, err := e2ebindings.NewProxy(config.BatchAuthenticatorAddress, d.L1)
+	require.NoError(t, err)
+
+	var result []interface{}
+	proxyRaw := &e2ebindings.ProxyRaw{Contract: proxyContract}
+	err = proxyRaw.Call(&bind.CallOpts{}, &result, "admin")
+	require.NoError(t, err)
+	require.Len(t, result, 1, "admin() should return one value")
+	proxyAdminAddress := result[0].(common.Address)
+	require.NotEqual(t, proxyAdminAddress, common.Address{}, "ProxyAdmin address should not be zero")
+
+	// Get ProxyAdmin contract binding
+	proxyAdmin, err := e2ebindings.NewProxyAdmin(proxyAdminAddress, d.L1)
+	require.NoError(t, err)
+
+	// Verify current owner matches
+	proxyAdminOwner, err := proxyAdmin.Owner(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Equal(t, currentOwner, proxyAdminOwner, "BatchAuthenticator owner should match ProxyAdmin owner")
+
 	// Use batch authenticator owner key to sign the transaction
 	batchAuthenticatorPrivateKeyHex := os.Getenv("BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY")
 	require.NotEmpty(t, batchAuthenticatorPrivateKeyHex, "BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY must be set")
@@ -60,8 +83,8 @@ func TestChangeBatchInboxOwner(t *testing.T) {
 	batchAuthenticatorOwnerOpts, err := bind.NewKeyedTransactorWithChainID(batchAuthenticatorKey, l1ChainID)
 	require.NoError(t, err)
 
-	// Call TransferOwnership
-	tx, err := batchAuthenticator.TransferOwnership(batchAuthenticatorOwnerOpts, bobAddress)
+	// Call TransferOwnership on the ProxyAdmin directly
+	tx, err := proxyAdmin.TransferOwnership(batchAuthenticatorOwnerOpts, bobAddress)
 	require.NoError(t, err)
 
 	// Wait for transaction receipt and check if it succeeded

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ run-l1-espresso-contracts-tests: compile-contracts
  (cd packages/contracts-bedrock && forge test --match-path "/**/test/L1/Batch*.t.sol")
 
 compile-contracts-fast:
- (cd packages/contracts-bedrock && forge build --offline --skip "/**/test/**")
+ (cd packages/contracts-bedrock && forge build --offline --skip "/**/test/**" && just fix-proxy-artifact)
 
 build-batcher-enclave-image:
  (cd kurtosis-devnet && just op-batcher-enclave-image)

--- a/packages/contracts-bedrock/interfaces/L1/IBatchAuthenticator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IBatchAuthenticator.sol
@@ -3,10 +3,6 @@ pragma solidity ^0.8.0;
 
 interface IBatchAuthenticator {
     event Initialized(uint8 version);
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner
-    );
 
     function authenticateBatchInfo(
         bytes32 commitment,
@@ -31,10 +27,6 @@ interface IBatchAuthenticator {
         bytes memory attestationTbs,
         bytes memory signature
     ) external;
-
-    function renounceOwnership() external;
-
-    function transferOwnership(address newOwner) external;
 
     function validBatchInfo(bytes32) external view returns (bool);
 

--- a/packages/contracts-bedrock/interfaces/L1/IBatchAuthenticator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IBatchAuthenticator.sol
@@ -42,10 +42,7 @@ interface IBatchAuthenticator {
 
     function switchBatcher() external;
 
-    function __constructor__(
-        address _espressoTEEVerifier,
-        address _teeBatcher,
-        address _nonTeeBatcher,
-        address _owner
-    ) external;
+    function setTeeBatcher(address _newTeeBatcher) external;
+
+    function setNonTeeBatcher(address _newNonTeeBatcher) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IBatchAuthenticator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IBatchAuthenticator.sol
@@ -11,7 +11,7 @@ interface IBatchAuthenticator {
 
     function decodeAttestationTbs(
         bytes memory attestation
-    ) external view returns (bytes memory, bytes memory);
+    ) external pure returns (bytes memory, bytes memory);
 
     function espressoTEEVerifier() external view returns (address);
 

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -13,6 +13,8 @@ import { IEspressoTEEVerifier } from "@espresso-tee-contracts/interface/IEspress
 import { EspressoTEEVerifier } from "@espresso-tee-contracts/EspressoTEEVerifier.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { BatchAuthenticator } from "src/L1/BatchAuthenticator.sol";
@@ -112,10 +114,10 @@ contract DeployEspresso is Script {
         Proxy proxy = new Proxy(address(proxyAdmin));
         vm.label(address(proxy), "BatchAuthenticatorProxy");
         vm.broadcast(msg.sender);
+        proxyAdmin.setProxyType(address(proxy), ProxyAdmin.ProxyType.ERC1967);
+        vm.broadcast(msg.sender);
         BatchAuthenticator impl = new BatchAuthenticator();
         vm.label(address(impl), "BatchAuthenticatorImpl");
-        vm.broadcast(msg.sender);
-        proxyAdmin.setProxyType(address(proxy), ProxyAdmin.ProxyType.ERC1967);
 
         // Initialize the proxy.
         bytes memory initData = abi.encodeCall(
@@ -137,7 +139,7 @@ contract DeployEspresso is Script {
         return batchAuthenticator;
     }
 
-    function deployTEEVerifier(DeployEspressoInput input, address deployerAddress) public returns (IEspressoTEEVerifier) {
+    function deployTEEVerifier(DeployEspressoInput input, address /* deployerAddress */) public returns (IEspressoTEEVerifier) {
         IEspressoNitroTEEVerifier nitroTEEVerifier = IEspressoNitroTEEVerifier(input.nitroTEEVerifier());
         vm.broadcast(msg.sender);
         IEspressoTEEVerifier impl = new EspressoTEEVerifier(

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -103,16 +103,18 @@ contract DeployEspresso is Script {
         returns (IBatchAuthenticator)
     {
         // Deploy the proxy admin, the proxy, and the batch authenticator implementation.
-        vm.broadcast(deployerAddress);
-        ProxyAdmin proxyAdmin = new ProxyAdmin(deployerAddress);
+        // We create ProxyAdmin with msg.sender as the owner to ensure broadcasts come from
+        // the expected address, then transfer ownership to deployerAddress afterward.
+        vm.broadcast(msg.sender);
+        ProxyAdmin proxyAdmin = new ProxyAdmin(msg.sender);
         vm.label(address(proxyAdmin), "BatchAuthenticatorProxyAdmin");
-        vm.broadcast(deployerAddress);
+        vm.broadcast(msg.sender);
         Proxy proxy = new Proxy(address(proxyAdmin));
         vm.label(address(proxy), "BatchAuthenticatorProxy");
-        vm.broadcast(deployerAddress);
+        vm.broadcast(msg.sender);
         BatchAuthenticator impl = new BatchAuthenticator();
         vm.label(address(impl), "BatchAuthenticatorImpl");
-        vm.broadcast(deployerAddress);
+        vm.broadcast(msg.sender);
         proxyAdmin.setProxyType(address(proxy), ProxyAdmin.ProxyType.ERC1967);
 
         // Initialize the proxy.
@@ -120,8 +122,14 @@ contract DeployEspresso is Script {
             BatchAuthenticator.initialize,
             (teeVerifier, input.teeBatcher(), input.nonTeeBatcher())
         );
-        vm.broadcast(deployerAddress);
+        vm.broadcast(msg.sender);
         proxyAdmin.upgradeAndCall(payable(address(proxy)), address(impl), initData);
+
+        // Transfer ownership to the desired deployerAddress if it differs from msg.sender.
+        if (deployerAddress != msg.sender) {
+            vm.broadcast(msg.sender);
+            proxyAdmin.transferOwnership(deployerAddress);
+        }
 
         // Return the proxied contract.
         IBatchAuthenticator batchAuthenticator = IBatchAuthenticator(address(proxy));
@@ -131,7 +139,7 @@ contract DeployEspresso is Script {
 
     function deployTEEVerifier(DeployEspressoInput input, address deployerAddress) public returns (IEspressoTEEVerifier) {
         IEspressoNitroTEEVerifier nitroTEEVerifier = IEspressoNitroTEEVerifier(input.nitroTEEVerifier());
-        vm.broadcast(deployerAddress);
+        vm.broadcast(msg.sender);
         IEspressoTEEVerifier impl = new EspressoTEEVerifier(
             // SGX TEE verifier is not yet implemented
             IEspressoSGXTEEVerifier(address(0)),
@@ -150,7 +158,7 @@ contract DeployEspresso is Script {
         public
     {
         bytes32 salt = input.salt();
-        vm.broadcast(deployerAddress);
+        vm.broadcast(msg.sender);
         IBatchInbox impl = IBatchInbox(
             DeployUtils.create2({
                 _name: "BatchInbox",

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -87,7 +87,7 @@ contract DeployEspressoOutput is BaseDeployIO {
 
 contract DeployEspresso is Script {
     function run(DeployEspressoInput input, DeployEspressoOutput output, address deployerAddress) public {
-        IEspressoTEEVerifier teeVerifier = deployTEEVerifier(input);
+        IEspressoTEEVerifier teeVerifier = deployTEEVerifier(input, deployerAddress);
         IBatchAuthenticator batchAuthenticator = deployBatchAuthenticator(input, output, teeVerifier, deployerAddress);
         deployBatchInbox(input, output, batchAuthenticator, deployerAddress);
         checkOutput(output);
@@ -97,22 +97,22 @@ contract DeployEspresso is Script {
         DeployEspressoInput input,
         DeployEspressoOutput output,
         IEspressoTEEVerifier teeVerifier,
-        address owner
+        address deployerAddress
     )
         public
         returns (IBatchAuthenticator)
     {
         // Deploy the proxy admin, the proxy, and the batch authenticator implementation.
-        vm.broadcast(msg.sender);
-        ProxyAdmin proxyAdmin = new ProxyAdmin(owner);
+        vm.broadcast(deployerAddress);
+        ProxyAdmin proxyAdmin = new ProxyAdmin(deployerAddress);
         vm.label(address(proxyAdmin), "BatchAuthenticatorProxyAdmin");
-        vm.broadcast(msg.sender);
+        vm.broadcast(deployerAddress);
         Proxy proxy = new Proxy(address(proxyAdmin));
         vm.label(address(proxy), "BatchAuthenticatorProxy");
-        vm.broadcast(msg.sender);
+        vm.broadcast(deployerAddress);
         BatchAuthenticator impl = new BatchAuthenticator();
         vm.label(address(impl), "BatchAuthenticatorImpl");
-        vm.broadcast(owner);
+        vm.broadcast(deployerAddress);
         proxyAdmin.setProxyType(address(proxy), ProxyAdmin.ProxyType.ERC1967);
 
         // Initialize the proxy.
@@ -120,7 +120,7 @@ contract DeployEspresso is Script {
             BatchAuthenticator.initialize,
             (teeVerifier, input.teeBatcher(), input.nonTeeBatcher())
         );
-        vm.broadcast(owner);
+        vm.broadcast(deployerAddress);
         proxyAdmin.upgradeAndCall(payable(address(proxy)), address(impl), initData);
 
         // Return the proxied contract.
@@ -129,9 +129,9 @@ contract DeployEspresso is Script {
         return batchAuthenticator;
     }
 
-    function deployTEEVerifier(DeployEspressoInput input) public returns (IEspressoTEEVerifier) {
+    function deployTEEVerifier(DeployEspressoInput input, address deployerAddress) public returns (IEspressoTEEVerifier) {
         IEspressoNitroTEEVerifier nitroTEEVerifier = IEspressoNitroTEEVerifier(input.nitroTEEVerifier());
-        vm.broadcast(msg.sender);
+        vm.broadcast(deployerAddress);
         IEspressoTEEVerifier impl = new EspressoTEEVerifier(
             // SGX TEE verifier is not yet implemented
             IEspressoSGXTEEVerifier(address(0)),
@@ -145,18 +145,18 @@ contract DeployEspresso is Script {
         DeployEspressoInput input,
         DeployEspressoOutput output,
         IBatchAuthenticator batchAuthenticator,
-        address owner
+        address deployerAddress
     )
         public
     {
         bytes32 salt = input.salt();
-        vm.broadcast(msg.sender);
+        vm.broadcast(deployerAddress);
         IBatchInbox impl = IBatchInbox(
             DeployUtils.create2({
                 _name: "BatchInbox",
                 _salt: salt,
                 _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(IBatchInbox.__constructor__, (address(batchAuthenticator), owner))
+                    abi.encodeCall(IBatchInbox.__constructor__, (address(batchAuthenticator), deployerAddress))
                 )
             })
         );

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -11,6 +11,11 @@ import { IEspressoNitroTEEVerifier } from "@espresso-tee-contracts/interface/IEs
 import { IEspressoSGXTEEVerifier } from "@espresso-tee-contracts/interface/IEspressoSGXTEEVerifier.sol";
 import { IEspressoTEEVerifier } from "@espresso-tee-contracts/interface/IEspressoTEEVerifier.sol";
 import { EspressoTEEVerifier } from "@espresso-tee-contracts/EspressoTEEVerifier.sol";
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { BatchAuthenticator } from "src/L1/BatchAuthenticator.sol";
 import { console2 as console } from "forge-std/console2.sol";
 
 contract DeployEspressoInput is BaseDeployIO {
@@ -97,24 +102,31 @@ contract DeployEspresso is Script {
         public
         returns (IBatchAuthenticator)
     {
-        bytes32 salt = input.salt();
+        // Deploy the proxy admin, the proxy, and the batch authenticator implementation.
         vm.broadcast(msg.sender);
-        IBatchAuthenticator impl = IBatchAuthenticator(
-            DeployUtils.create2({
-                _name: "BatchAuthenticator",
-                _salt: salt,
-                _args: DeployUtils.encodeConstructor(
-                    abi.encodeCall(
-                        IBatchAuthenticator.__constructor__,
-                        (address(teeVerifier), input.teeBatcher(), input.nonTeeBatcher(), owner)
-                    )
-                )
-            })
-        );
+        ProxyAdmin proxyAdmin = new ProxyAdmin(owner);
+        vm.label(address(proxyAdmin), "BatchAuthenticatorProxyAdmin");
+        vm.broadcast(msg.sender);
+        Proxy proxy = new Proxy(address(proxyAdmin));
+        vm.label(address(proxy), "BatchAuthenticatorProxy");
+        vm.broadcast(msg.sender);
+        BatchAuthenticator impl = new BatchAuthenticator();
         vm.label(address(impl), "BatchAuthenticatorImpl");
+        vm.broadcast(owner);
+        proxyAdmin.setProxyType(address(proxy), ProxyAdmin.ProxyType.ERC1967);
 
-        output.set(output.batchAuthenticatorAddress.selector, address(impl));
-        return impl;
+        // Initialize the proxy.
+        bytes memory initData = abi.encodeCall(
+            BatchAuthenticator.initialize,
+            (teeVerifier, input.teeBatcher(), input.nonTeeBatcher())
+        );
+        vm.broadcast(owner);
+        proxyAdmin.upgradeAndCall(payable(address(proxy)), address(impl), initData);
+
+        // Return the proxied contract.
+        IBatchAuthenticator batchAuthenticator = IBatchAuthenticator(address(proxy));
+        output.set(output.batchAuthenticatorAddress.selector, address(batchAuthenticator));
+        return batchAuthenticator;
     }
 
     function deployTEEVerifier(DeployEspressoInput input) public returns (IEspressoTEEVerifier) {

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -107,11 +107,26 @@ contract DeployEspresso is Script {
         // Deploy the proxy admin, the proxy, and the batch authenticator implementation.
         // We create ProxyAdmin with msg.sender as the owner to ensure broadcasts come from
         // the expected address, then transfer ownership to deployerAddress afterward.
+        // Use DeployUtils.create1 to ensure artifacts are available for vm.getCode calls.
         vm.broadcast(msg.sender);
-        ProxyAdmin proxyAdmin = new ProxyAdmin(msg.sender);
+        ProxyAdmin proxyAdmin = ProxyAdmin(
+            payable(
+                DeployUtils.create1({
+                    _name: "ProxyAdmin",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxyAdmin.__constructor__, (msg.sender)))
+                })
+            )
+        );
         vm.label(address(proxyAdmin), "BatchAuthenticatorProxyAdmin");
         vm.broadcast(msg.sender);
-        Proxy proxy = new Proxy(address(proxyAdmin));
+        Proxy proxy = Proxy(
+            payable(
+                DeployUtils.create1({
+                    _name: "Proxy",
+                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (address(proxyAdmin))))
+                })
+            )
+        );
         vm.label(address(proxy), "BatchAuthenticatorProxy");
         vm.broadcast(msg.sender);
         proxyAdmin.setProxyType(address(proxy), ProxyAdmin.ProxyType.ERC1967);

--- a/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployEspresso.s.sol
@@ -13,8 +13,6 @@ import { IEspressoTEEVerifier } from "@espresso-tee-contracts/interface/IEspress
 import { EspressoTEEVerifier } from "@espresso-tee-contracts/EspressoTEEVerifier.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
-import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IProxy } from "interfaces/universal/IProxy.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { BatchAuthenticator } from "src/L1/BatchAuthenticator.sol";
@@ -135,10 +133,8 @@ contract DeployEspresso is Script {
         vm.label(address(impl), "BatchAuthenticatorImpl");
 
         // Initialize the proxy.
-        bytes memory initData = abi.encodeCall(
-            BatchAuthenticator.initialize,
-            (teeVerifier, input.teeBatcher(), input.nonTeeBatcher())
-        );
+        bytes memory initData =
+            abi.encodeCall(BatchAuthenticator.initialize, (teeVerifier, input.teeBatcher(), input.nonTeeBatcher()));
         vm.broadcast(msg.sender);
         proxyAdmin.upgradeAndCall(payable(address(proxy)), address(impl), initData);
 
@@ -154,7 +150,13 @@ contract DeployEspresso is Script {
         return batchAuthenticator;
     }
 
-    function deployTEEVerifier(DeployEspressoInput input, address /* deployerAddress */) public returns (IEspressoTEEVerifier) {
+    function deployTEEVerifier(
+        DeployEspressoInput input,
+        address /* deployerAddress */
+    )
+        public
+        returns (IEspressoTEEVerifier)
+    {
         IEspressoNitroTEEVerifier nitroTEEVerifier = IEspressoNitroTEEVerifier(input.nitroTEEVerifier());
         vm.broadcast(msg.sender);
         IEspressoTEEVerifier impl = new EspressoTEEVerifier(

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -22,6 +22,12 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
     /// @notice Emitted when a signer registration is initiated through this contract.
     event SignerRegistrationInitiated(address indexed caller);
 
+    /// @notice Emitted when the TEE batcher address is updated.
+    event TeeBatcherUpdated(address indexed oldTeeBatcher, address indexed newTeeBatcher);
+
+    /// @notice Emitted when the non-TEE batcher address is updated.
+    event NonTeeBatcherUpdated(address indexed oldNonTeeBatcher, address indexed newNonTeeBatcher);
+
     /// @notice Error thrown when an invalid address (zero address) is provided.
     error InvalidAddress(address contract_);
 
@@ -72,6 +78,24 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
     function switchBatcher() external {
         _assertOnlyProxyAdminOrProxyAdminOwner();
         activeIsTee = !activeIsTee;
+    }
+
+    /// @notice Updates the TEE batcher address.
+    function setTeeBatcher(address _newTeeBatcher) external {
+        _assertOnlyProxyAdminOrProxyAdminOwner();
+        if (_newTeeBatcher == address(0)) revert InvalidAddress(_newTeeBatcher);
+        address oldTeeBatcher = teeBatcher;
+        teeBatcher = _newTeeBatcher;
+        emit TeeBatcherUpdated(oldTeeBatcher, _teeBatcher);
+    }
+
+    /// @notice Updates the non-TEE batcher address.
+    function setNonTeeBatcher(address _newNonTeeBatcher) external {
+        _assertOnlyProxyAdminOrProxyAdminOwner();
+        if (_newNonTeeBatcher == address(0)) revert InvalidAddress(_newNonTeeBatcher);
+        address oldNonTeeBatcher = nonTeeBatcher;
+        nonTeeBatcher = _newNonTeeBatcher;
+        emit NonTeeBatcherUpdated(oldNonTeeBatcher, _newNonTeeBatcher);
     }
 
     function authenticateBatchInfo(bytes32 commitment, bytes calldata _signature) external {

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -74,6 +74,11 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
         activeIsTee = true;
     }
 
+    /// @notice Returns the owner of the ProxyAdmin that owns this proxy.
+    function owner() external view returns (address) {
+        return proxyAdminOwner();
+    }
+
     /// @notice Toggles the active batcher between the TEE and non-TEE batcher.
     function switchBatcher() external {
         _assertOnlyProxyAdminOrProxyAdminOwner();

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -141,7 +141,7 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
     /// @dev This function is not implemented as decodeAttestationTbs is not available
     ///      through the IEspressoNitroTEEVerifier interface. Use the NitroValidator
     ///      contract directly if this functionality is needed.
-    function decodeAttestationTbs(bytes memory /* attestation */) external pure returns (bytes memory, bytes memory) {
+    function decodeAttestationTbs(bytes memory /* attestation */ ) external pure returns (bytes memory, bytes memory) {
         revert("BatchAuthenticator: decodeAttestationTbs not implemented - use NitroValidator directly");
     }
 }

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -86,7 +86,7 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
         if (_newTeeBatcher == address(0)) revert InvalidAddress(_newTeeBatcher);
         address oldTeeBatcher = teeBatcher;
         teeBatcher = _newTeeBatcher;
-        emit TeeBatcherUpdated(oldTeeBatcher, _teeBatcher);
+        emit TeeBatcherUpdated(oldTeeBatcher, _newTeeBatcher);
     }
 
     /// @notice Updates the non-TEE batcher address.

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -129,4 +129,20 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
         espressoTEEVerifier.registerSigner(attestationTbs, signature, IEspressoTEEVerifier.TeeType.NITRO);
         emit SignerRegistrationInitiated(msg.sender);
     }
+
+    /// @notice Returns the address of the Nitro TEE validator.
+    function nitroValidator() external view returns (address) {
+        return address(espressoTEEVerifier.espressoNitroTEEVerifier());
+    }
+
+    /// @notice Decodes an attestation into its TBS (to-be-signed) portion and signature.
+    /// @param attestation The attestation bytes to decode.
+    /// @return attestationTbs The TBS portion of the attestation.
+    /// @return signature The signature portion of the attestation.
+    /// @dev This function is not implemented as decodeAttestationTbs is not available
+    ///      through the IEspressoNitroTEEVerifier interface. Use the NitroValidator
+    ///      contract directly if this functionality is needed.
+    function decodeAttestationTbs(bytes memory /* attestation */) external view returns (bytes memory, bytes memory) {
+        revert("BatchAuthenticator: decodeAttestationTbs not implemented - use NitroValidator directly");
+    }
 }

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -136,7 +136,6 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
     }
 
     /// @notice Decodes an attestation into its TBS (to-be-signed) portion and signature.
-    /// @param attestation The attestation bytes to decode.
     /// @return attestationTbs The TBS portion of the attestation.
     /// @return signature The signature portion of the attestation.
     /// @dev This function is not implemented as decodeAttestationTbs is not available

--- a/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
+++ b/packages/contracts-bedrock/src/L1/BatchAuthenticator.sol
@@ -141,7 +141,7 @@ contract BatchAuthenticator is ISemver, Initializable, ProxyAdminOwnedBase, Rein
     /// @dev This function is not implemented as decodeAttestationTbs is not available
     ///      through the IEspressoNitroTEEVerifier interface. Use the NitroValidator
     ///      contract directly if this functionality is needed.
-    function decodeAttestationTbs(bytes memory /* attestation */) external view returns (bytes memory, bytes memory) {
+    function decodeAttestationTbs(bytes memory /* attestation */) external pure returns (bytes memory, bytes memory) {
         revert("BatchAuthenticator: decodeAttestationTbs not implemented - use NitroValidator directly");
     }
 }

--- a/packages/contracts-bedrock/test/L1/BatchAuthenticator.t.sol
+++ b/packages/contracts-bedrock/test/L1/BatchAuthenticator.t.sol
@@ -322,20 +322,6 @@ contract BatchAuthenticator_Test is Test {
         authenticator.setTeeBatcher(address(0));
     }
 
-    /// @notice Test that setTeeBatcher successfully updates the address.
-    function test_setTeeBatcher_succeeds() external {
-        BatchAuthenticator authenticator = _deployAndInitializeProxy();
-        address newTeeBatcher = address(0x9999);
-
-        vm.expectEmit(true, true, false, false);
-        emit TeeBatcherUpdated(teeBatcher, newTeeBatcher);
-
-        vm.prank(proxyAdminOwner);
-        authenticator.setTeeBatcher(newTeeBatcher);
-
-        assertEq(authenticator.teeBatcher(), newTeeBatcher);
-    }
-
     /// @notice Test that setNonTeeBatcher can only be called by ProxyAdmin or owner.
     function test_setNonTeeBatcher_onlyProxyAdminOrOwner() external {
         BatchAuthenticator authenticator = _deployAndInitializeProxy();
@@ -369,20 +355,6 @@ contract BatchAuthenticator_Test is Test {
         vm.prank(proxyAdminOwner);
         vm.expectRevert(abi.encodeWithSelector(BatchAuthenticator.InvalidAddress.selector, address(0)));
         authenticator.setNonTeeBatcher(address(0));
-    }
-
-    /// @notice Test that setNonTeeBatcher successfully updates the address.
-    function test_setNonTeeBatcher_succeeds() external {
-        BatchAuthenticator authenticator = _deployAndInitializeProxy();
-        address newNonTeeBatcher = address(0xAAAA);
-
-        vm.expectEmit(true, true, false, false);
-        emit NonTeeBatcherUpdated(nonTeeBatcher, newNonTeeBatcher);
-
-        vm.prank(proxyAdminOwner);
-        authenticator.setNonTeeBatcher(newNonTeeBatcher);
-
-        assertEq(authenticator.nonTeeBatcher(), newNonTeeBatcher);
     }
 
     /// @notice Test upgrade to new implementation with comprehensive state preservation.

--- a/packages/contracts-bedrock/test/L1/BatchAuthenticator.t.sol
+++ b/packages/contracts-bedrock/test/L1/BatchAuthenticator.t.sol
@@ -287,6 +287,104 @@ contract BatchAuthenticator_Test is Test {
         authenticator.registerSigner(attestationTbs, signature);
     }
 
+    /// @notice Test that setTeeBatcher can only be called by ProxyAdmin or owner.
+    function test_setTeeBatcher_onlyProxyAdminOrOwner() external {
+        BatchAuthenticator authenticator = _deployAndInitializeProxy();
+        address newTeeBatcher = address(0x9999);
+
+        // ProxyAdmin owner can set.
+        vm.expectEmit(true, true, false, false);
+        emit TeeBatcherUpdated(teeBatcher, newTeeBatcher);
+        vm.prank(proxyAdminOwner);
+        authenticator.setTeeBatcher(newTeeBatcher);
+        assertEq(authenticator.teeBatcher(), newTeeBatcher);
+
+        // ProxyAdmin can set.
+        address anotherTeeBatcher = address(0x8888);
+        vm.expectEmit(true, true, false, false);
+        emit TeeBatcherUpdated(newTeeBatcher, anotherTeeBatcher);
+        vm.prank(address(proxyAdmin));
+        authenticator.setTeeBatcher(anotherTeeBatcher);
+        assertEq(authenticator.teeBatcher(), anotherTeeBatcher);
+
+        // Unauthorized cannot set.
+        vm.prank(unauthorized);
+        vm.expectRevert();
+        authenticator.setTeeBatcher(address(0x7777));
+    }
+
+    /// @notice Test that setTeeBatcher reverts when zero address is provided.
+    function test_setTeeBatcher_revertsWhenZeroAddress() external {
+        BatchAuthenticator authenticator = _deployAndInitializeProxy();
+
+        vm.prank(proxyAdminOwner);
+        vm.expectRevert(abi.encodeWithSelector(BatchAuthenticator.InvalidAddress.selector, address(0)));
+        authenticator.setTeeBatcher(address(0));
+    }
+
+    /// @notice Test that setTeeBatcher successfully updates the address.
+    function test_setTeeBatcher_succeeds() external {
+        BatchAuthenticator authenticator = _deployAndInitializeProxy();
+        address newTeeBatcher = address(0x9999);
+
+        vm.expectEmit(true, true, false, false);
+        emit TeeBatcherUpdated(teeBatcher, newTeeBatcher);
+
+        vm.prank(proxyAdminOwner);
+        authenticator.setTeeBatcher(newTeeBatcher);
+
+        assertEq(authenticator.teeBatcher(), newTeeBatcher);
+    }
+
+    /// @notice Test that setNonTeeBatcher can only be called by ProxyAdmin or owner.
+    function test_setNonTeeBatcher_onlyProxyAdminOrOwner() external {
+        BatchAuthenticator authenticator = _deployAndInitializeProxy();
+        address newNonTeeBatcher = address(0xAAAA);
+
+        // ProxyAdmin owner can set.
+        vm.expectEmit(true, true, false, false);
+        emit NonTeeBatcherUpdated(nonTeeBatcher, newNonTeeBatcher);
+        vm.prank(proxyAdminOwner);
+        authenticator.setNonTeeBatcher(newNonTeeBatcher);
+        assertEq(authenticator.nonTeeBatcher(), newNonTeeBatcher);
+
+        // ProxyAdmin can set.
+        address anotherNonTeeBatcher = address(0xBBBB);
+        vm.expectEmit(true, true, false, false);
+        emit NonTeeBatcherUpdated(newNonTeeBatcher, anotherNonTeeBatcher);
+        vm.prank(address(proxyAdmin));
+        authenticator.setNonTeeBatcher(anotherNonTeeBatcher);
+        assertEq(authenticator.nonTeeBatcher(), anotherNonTeeBatcher);
+
+        // Unauthorized cannot set.
+        vm.prank(unauthorized);
+        vm.expectRevert();
+        authenticator.setNonTeeBatcher(address(0xCCCC));
+    }
+
+    /// @notice Test that setNonTeeBatcher reverts when zero address is provided.
+    function test_setNonTeeBatcher_revertsWhenZeroAddress() external {
+        BatchAuthenticator authenticator = _deployAndInitializeProxy();
+
+        vm.prank(proxyAdminOwner);
+        vm.expectRevert(abi.encodeWithSelector(BatchAuthenticator.InvalidAddress.selector, address(0)));
+        authenticator.setNonTeeBatcher(address(0));
+    }
+
+    /// @notice Test that setNonTeeBatcher successfully updates the address.
+    function test_setNonTeeBatcher_succeeds() external {
+        BatchAuthenticator authenticator = _deployAndInitializeProxy();
+        address newNonTeeBatcher = address(0xAAAA);
+
+        vm.expectEmit(true, true, false, false);
+        emit NonTeeBatcherUpdated(nonTeeBatcher, newNonTeeBatcher);
+
+        vm.prank(proxyAdminOwner);
+        authenticator.setNonTeeBatcher(newNonTeeBatcher);
+
+        assertEq(authenticator.nonTeeBatcher(), newNonTeeBatcher);
+    }
+
     /// @notice Test upgrade to new implementation with comprehensive state preservation.
     function test_upgrade_preservesState() external {
         // Create and initialize a proxy.
@@ -328,6 +426,8 @@ contract BatchAuthenticator_Test is Test {
     // Event declarations for expectEmit.
     event BatchInfoAuthenticated(bytes32 indexed commitment, address indexed signer);
     event SignerRegistrationInitiated(address indexed caller);
+    event TeeBatcherUpdated(address indexed oldTeeBatcher, address indexed newTeeBatcher);
+    event NonTeeBatcherUpdated(address indexed oldNonTeeBatcher, address indexed newNonTeeBatcher);
 }
 
 /// @notice Fork tests for BatchAuthenticator on Sepolia.
@@ -474,4 +574,6 @@ contract BatchAuthenticator_Fork_Test is Test {
     // Event declarations for expectEmit.
     event BatchInfoAuthenticated(bytes32 indexed commitment, address indexed signer);
     event SignerRegistrationInitiated(address indexed caller);
+    event TeeBatcherUpdated(address indexed oldTeeBatcher, address indexed newTeeBatcher);
+    event NonTeeBatcherUpdated(address indexed oldNonTeeBatcher, address indexed newNonTeeBatcher);
 }


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1212919936317874?focus=true.

**Note**: this PR is to be merged to `keyao/transparent-proxy`, which is associated with https://github.com/EspressoSystems/optimism-espresso-integration/pull/337.

### This PR:
* Adds setters for the TEE and non-TEE batcher addresses.
* Tests the address update for both batchers.
* Fixes broken devnet and integration tests caused by the upstream branch.

### How to test this PR:
* Verify that all CI workflows pass, including new and existing tests.

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212919936317889