### PR TITLE
Limit batch buffer capacity

### DIFF
--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -24,6 +24,7 @@ const (
 )
 
 var ErrAtCapacity = errors.New("batch buffer at capacity")
+var ErrDuplicateBatch = errors.New("duplicate batch")
 
 type Batch interface {
 	Number() uint64
@@ -75,10 +76,11 @@ func (b *BatchBuffer[B]) Insert(batch B) error {
 		}
 	})
 
-	if !alreadyExists {
-		b.batches = slices.Insert(b.batches, pos, batch)
+	if alreadyExists {
+		return ErrDuplicateBatch
 	}
 
+	b.batches = slices.Insert(b.batches, pos, batch)
 	return nil
 }
 

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -1,7 +1,7 @@
 package espresso
 
 import (
-	"cmp"
+	"errors"
 	"slices"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -18,12 +18,12 @@ const (
 	BatchAccept
 	// BatchUndecided indicates we are lacking L1 information until we can proceed batch filtering
 	BatchUndecided
-	// BatchFuture indicates that the batch may be valid, but cannot be processed yet and should be checked again later
-	BatchFuture
 	// BatchPast indicates that the batch is from the past, i.e. its timestamp is smaller or equal
 	// to the safe head's timestamp.
 	BatchPast
 )
+
+var ErrAtCapacity = errors.New("batch buffer at capacity")
 
 type Batch interface {
 	Number() uint64
@@ -33,13 +33,19 @@ type Batch interface {
 }
 
 type BatchBuffer[B Batch] struct {
-	batches []B
+	batches  []B
+	capacity uint64
 }
 
-func NewBatchBuffer[B Batch]() BatchBuffer[B] {
+func NewBatchBuffer[B Batch](capacity uint64) BatchBuffer[B] {
 	return BatchBuffer[B]{
-		batches: []B{},
+		capacity: capacity,
+		batches:  []B{},
 	}
+}
+
+func (b BatchBuffer[B]) Capacity() uint64 {
+	return b.capacity
 }
 
 func (b BatchBuffer[B]) Len() int {
@@ -50,17 +56,28 @@ func (b *BatchBuffer[B]) Clear() {
 	b.batches = nil
 }
 
-func (b *BatchBuffer[B]) Insert(batch B, i int) {
-	b.batches = slices.Insert(b.batches, i, batch)
-}
+func (b *BatchBuffer[B]) Insert(batch B) error {
+	if b.Len() >= int(b.capacity) {
+		return ErrAtCapacity
+	}
 
-func (b *BatchBuffer[B]) TryInsert(batch B) (int, bool) {
-	pos, batchIsRecorded := slices.BinarySearchFunc(b.batches, batch, func(x, y B) int {
-		return cmp.Compare(x.Number(), y.Number())
+	pos, alreadyExists := slices.BinarySearchFunc(b.batches, batch, func(a, t B) int {
+		// Note: we use a custom comparison function that returns 0 only if the batches are actually
+		// the same to ensure that newer batches with the same number are stored later in the buffer
+		if a.Number() > t.Number() {
+			return 1
+		} else if a.Number() == t.Number() && a.Hash() == t.Hash() {
+			return 0
+		} else {
+			return -1
+		}
 	})
 
-	return pos, batchIsRecorded
+	if !alreadyExists {
+		b.batches = slices.Insert(b.batches, pos, batch)
+	}
 
+	return nil
 }
 
 func (b *BatchBuffer[B]) Get(i int) *B {

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -57,7 +57,7 @@ func (b *BatchBuffer[B]) Clear() {
 }
 
 func (b *BatchBuffer[B]) Insert(batch B) error {
-	if b.Len() >= int(b.capacity) {
+if uint64(b.Len()) >= b.capacity {
 		return ErrAtCapacity
 	}
 

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -39,8 +39,8 @@ type BatchBuffer[B Batch] struct {
 
 func NewBatchBuffer[B Batch](capacity uint64) BatchBuffer[B] {
 	return BatchBuffer[B]{
-		capacity: capacity,
 		batches:  []B{},
+		capacity: capacity,
 	}
 }
 
@@ -64,10 +64,12 @@ func (b *BatchBuffer[B]) Insert(batch B) error {
 	pos, alreadyExists := slices.BinarySearchFunc(b.batches, batch, func(a, t B) int {
 		// Note: we use a custom comparison function that returns 0 only if the batches are actually
 		// the same to ensure that newer batches with the same number are stored later in the buffer
+		if a.Hash() == t.Hash() {
+			return 0
+		}
+
 		if a.Number() > t.Number() {
 			return 1
-		} else if a.Number() == t.Number() && a.Hash() == t.Hash() {
-			return 0
 		} else {
 			return -1
 		}

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -57,7 +57,7 @@ func (b *BatchBuffer[B]) Clear() {
 }
 
 func (b *BatchBuffer[B]) Insert(batch B) error {
-if uint64(b.Len()) >= b.capacity {
+	if uint64(b.Len()) >= b.capacity {
 		return ErrAtCapacity
 	}
 

--- a/espresso/batch_buffer_test.go
+++ b/espresso/batch_buffer_test.go
@@ -1,0 +1,288 @@
+package espresso
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBatch is a simple implementation of the Batch interface for testing
+type mockBatch struct {
+	number   uint64
+	hash     common.Hash
+	l1Origin eth.BlockID
+}
+
+func (m mockBatch) Number() uint64 {
+	return m.number
+}
+
+func (m mockBatch) L1Origin() eth.BlockID {
+	return m.l1Origin
+}
+
+func (m mockBatch) Header() *types.Header {
+	return &types.Header{
+		Number: big.NewInt(int64(m.number)),
+	}
+}
+
+func (m mockBatch) Hash() common.Hash {
+	return m.hash
+}
+
+// newMockBatch creates a mock batch with the given number and a hash derived from the number
+func newMockBatch(number uint64) mockBatch {
+	return mockBatch{
+		number: number,
+		hash:   common.BigToHash(big.NewInt(int64(number))),
+		l1Origin: eth.BlockID{
+			Number: number,
+			Hash:   common.BigToHash(big.NewInt(int64(number))),
+		},
+	}
+}
+
+// newMockBatchWithHash creates a mock batch with a specific number and hash
+func newMockBatchWithHash(number uint64, hash common.Hash) mockBatch {
+	return mockBatch{
+		number: number,
+		hash:   hash,
+		l1Origin: eth.BlockID{
+			Number: number,
+			Hash:   common.BigToHash(big.NewInt(int64(number))),
+		},
+	}
+}
+
+// TestBatchBufferInsertAtCapacity verifies that the buffer respects its capacity limit
+// and returns ErrAtCapacity when attempting to insert beyond capacity.
+func TestBatchBufferInsertAtCapacity(t *testing.T) {
+	const testCapacity uint64 = 3
+
+	// Create a buffer with small capacity
+	buffer := NewBatchBuffer[mockBatch](testCapacity)
+
+	// Verify Capacity() returns the configured capacity
+	require.Equal(t, testCapacity, buffer.Capacity())
+
+	// Verify buffer starts empty
+	require.Equal(t, 0, buffer.Len())
+
+	// Insert batches up to capacity
+	batch1 := newMockBatch(1)
+	batch2 := newMockBatch(2)
+	batch3 := newMockBatch(3)
+
+	err := buffer.Insert(batch1)
+	require.NoError(t, err)
+	require.Equal(t, 1, buffer.Len())
+
+	err = buffer.Insert(batch2)
+	require.NoError(t, err)
+	require.Equal(t, 2, buffer.Len())
+
+	err = buffer.Insert(batch3)
+	require.NoError(t, err)
+	require.Equal(t, 3, buffer.Len())
+
+	// Verify inserting beyond capacity returns ErrAtCapacity
+	batch4 := newMockBatch(4)
+	err = buffer.Insert(batch4)
+	require.ErrorIs(t, err, ErrAtCapacity)
+
+	// Verify buffer contents unchanged after failed insert
+	require.Equal(t, 3, buffer.Len())
+	require.Equal(t, testCapacity, buffer.Capacity())
+
+	// Verify the original batches are still accessible and in sorted order
+	got := buffer.Get(0)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(1), got.Number())
+
+	got = buffer.Get(1)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(2), got.Number())
+
+	got = buffer.Get(2)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(3), got.Number())
+
+	// Verify Get returns nil for out of bounds
+	require.Nil(t, buffer.Get(3))
+}
+
+// TestBatchBufferInsertDuplicateHandling verifies that:
+// - Inserting the exact same batch (same number AND same hash) does not create a duplicate
+// - Inserting a batch with the same number but different hash IS allowed
+func TestBatchBufferInsertDuplicateHandling(t *testing.T) {
+	const testCapacity uint64 = 10
+	const batchNumberN uint64 = 42
+
+	buffer := NewBatchBuffer[mockBatch](testCapacity)
+
+	// Create first batch with number N and hash H1
+	hashH1 := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	batchH1 := newMockBatchWithHash(batchNumberN, hashH1)
+
+	// Insert first batch
+	err := buffer.Insert(batchH1)
+	require.NoError(t, err)
+	require.Equal(t, 1, buffer.Len())
+
+	// Insert the exact same batch again (same number N, same hash H1)
+	// This should NOT create a duplicate
+	err = buffer.Insert(batchH1)
+	require.NoError(t, err)
+	require.Equal(t, 1, buffer.Len(), "duplicate batch with same number and hash should not be inserted")
+
+	// Create a different batch with same number N but different hash H2
+	hashH2 := common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222")
+	batchH2 := newMockBatchWithHash(batchNumberN, hashH2)
+
+	// Insert batch with same number but different hash - should be allowed
+	err = buffer.Insert(batchH2)
+	require.NoError(t, err)
+	require.Equal(t, 2, buffer.Len(), "batch with same number but different hash should be inserted")
+
+	// Verify both batches can be retrieved
+	first := buffer.Get(0)
+	require.NotNil(t, first)
+
+	second := buffer.Get(1)
+	require.NotNil(t, second)
+
+	// Verify they both have the same batch number
+	require.Equal(t, batchNumberN, first.Number())
+	require.Equal(t, batchNumberN, second.Number())
+
+	// Verify they have different hashes
+	require.NotEqual(t, first.Hash(), second.Hash())
+
+	// Verify insertion order is preserved (H1 first, H2 second)
+	require.Equal(t, hashH1, first.Hash())
+	require.Equal(t, hashH2, second.Hash())
+}
+
+// TestBatchBufferPeekAndPop verifies Peek returns without removing and Pop removes
+func TestBatchBufferPeekAndPop(t *testing.T) {
+	buffer := NewBatchBuffer[mockBatch](10)
+
+	// Verify Peek on empty buffer returns nil
+	require.Nil(t, buffer.Peek())
+
+	// Verify Pop on empty buffer returns nil
+	require.Nil(t, buffer.Pop())
+
+	// Insert a batch
+	batch1 := newMockBatch(1)
+	err := buffer.Insert(batch1)
+	require.NoError(t, err)
+
+	// Peek should return the batch without removing
+	peeked := buffer.Peek()
+	require.NotNil(t, peeked)
+	require.Equal(t, uint64(1), peeked.Number())
+	require.Equal(t, 1, buffer.Len())
+
+	// Peek again should return the same batch
+	peekedAgain := buffer.Peek()
+	require.Equal(t, peeked.Number(), peekedAgain.Number())
+	require.Equal(t, peeked.Hash(), peekedAgain.Hash())
+
+	// Pop should return and remove the batch
+	popped := buffer.Pop()
+	require.NotNil(t, popped)
+	require.Equal(t, uint64(1), popped.Number())
+	require.Equal(t, 0, buffer.Len())
+
+	// Pop on now-empty buffer should return nil
+	require.Nil(t, buffer.Pop())
+}
+
+// TestBatchBufferSortedOrder verifies batches are stored in sorted order by batch number
+func TestBatchBufferSortedOrder(t *testing.T) {
+	buffer := NewBatchBuffer[mockBatch](10)
+
+	// Insert batches out of order
+	err := buffer.Insert(newMockBatch(5))
+	require.NoError(t, err)
+	err = buffer.Insert(newMockBatch(2))
+	require.NoError(t, err)
+	err = buffer.Insert(newMockBatch(8))
+	require.NoError(t, err)
+	err = buffer.Insert(newMockBatch(1))
+	require.NoError(t, err)
+
+	require.Equal(t, 4, buffer.Len())
+
+	// Verify Get returns them in sorted order
+	require.Equal(t, uint64(1), buffer.Get(0).Number())
+	require.Equal(t, uint64(2), buffer.Get(1).Number())
+	require.Equal(t, uint64(5), buffer.Get(2).Number())
+	require.Equal(t, uint64(8), buffer.Get(3).Number())
+
+	// Verify Pop returns them in sorted order
+	require.Equal(t, uint64(1), buffer.Pop().Number())
+	require.Equal(t, uint64(2), buffer.Pop().Number())
+	require.Equal(t, uint64(5), buffer.Pop().Number())
+	require.Equal(t, uint64(8), buffer.Pop().Number())
+
+	// Buffer should be empty now
+	require.Equal(t, 0, buffer.Len())
+}
+
+// TestBatchBufferClear verifies Clear removes all batches
+func TestBatchBufferClear(t *testing.T) {
+	buffer := NewBatchBuffer[mockBatch](10)
+
+	// Insert some batches
+	err := buffer.Insert(newMockBatch(1))
+	require.NoError(t, err)
+	err = buffer.Insert(newMockBatch(2))
+	require.NoError(t, err)
+	err = buffer.Insert(newMockBatch(3))
+	require.NoError(t, err)
+	require.Equal(t, 3, buffer.Len())
+
+	// Clear the buffer
+	buffer.Clear()
+
+	// Verify buffer is empty
+	require.Equal(t, 0, buffer.Len())
+	require.Nil(t, buffer.Peek())
+	require.Nil(t, buffer.Pop())
+	require.Nil(t, buffer.Get(0))
+
+	// Verify capacity is unchanged
+	require.Equal(t, uint64(10), buffer.Capacity())
+
+	// Verify we can insert again after clear
+	err = buffer.Insert(newMockBatch(1))
+	require.NoError(t, err)
+	require.Equal(t, 1, buffer.Len())
+}
+
+// TestBatchBufferGetOutOfBounds verifies Get returns nil for invalid indices
+func TestBatchBufferGetOutOfBounds(t *testing.T) {
+	buffer := NewBatchBuffer[mockBatch](10)
+
+	// Empty buffer - all indices should return nil
+	require.Nil(t, buffer.Get(0))
+	require.Nil(t, buffer.Get(1))
+
+	// Insert one batch
+	err := buffer.Insert(newMockBatch(1))
+	require.NoError(t, err)
+
+	// Valid index
+	require.NotNil(t, buffer.Get(0))
+
+	// Invalid indices
+	require.Nil(t, buffer.Get(1))
+	require.Nil(t, buffer.Get(100))
+}

--- a/espresso/batch_buffer_test.go
+++ b/espresso/batch_buffer_test.go
@@ -135,9 +135,9 @@ func TestBatchBufferInsertDuplicateHandling(t *testing.T) {
 	require.Equal(t, 1, buffer.Len())
 
 	// Insert the exact same batch again (same number N, same hash H1)
-	// This should NOT create a duplicate
+	// This should return ErrDuplicateBatch and not create a duplicate
 	err = buffer.Insert(batchH1)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrDuplicateBatch)
 	require.Equal(t, 1, buffer.Len(), "duplicate batch with same number and hash should not be inserted")
 
 	// Create a different batch with same number N but different hash H2

--- a/espresso/environment/8_reorg_test.go
+++ b/espresso/environment/8_reorg_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/espresso"
 	env "github.com/ethereum-optimism/optimism/espresso/environment"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 	rpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -81,45 +83,8 @@ func TestBatcherWaitForFinality(t *testing.T) {
 	}
 }
 
-// VerifyL1OriginFinalized checks whether every batch in the batch buffer has a finalized L1
-// origin.
-func VerifyL1OriginFinalized(t *testing.T, streamer *espresso.BatchStreamer[derive.EspressoBatch], l1Client *ethclient.Client) bool {
-	for i := 0; i < streamer.BatchBuffer.Len(); i++ {
-		batch := streamer.BatchBuffer.Get(i)
-		origin := (batch).L1Origin()
-		finalizedL1, err := l1Client.BlockByNumber(context.Background(), big.NewInt(rpc.FinalizedBlockNumber.Int64()))
-		if err != nil {
-			return false
-		}
-
-		// Use the finalized L1 number from the Espresso streamer instead of the rollup client, in
-		// case they update their states at different times.
-		if origin.Number > finalizedL1.NumberU64() {
-			t.Log("L1 origin not finalized", "origin", origin.Number, "FinalizedL1", finalizedL1.NumberU64())
-			return false
-		}
-	}
-	return true
-}
-
-// VerifyBatchBufferUpdated checks whether the batch buffer is updated before the timeout.
-func VerifyBatchBufferUpdated(ctx context.Context, streamer *espresso.BatchStreamer[derive.EspressoBatch]) bool {
-	tickerBufferInsert := time.NewTicker(100 * time.Millisecond)
-	defer tickerBufferInsert.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		case <-tickerBufferInsert.C:
-			if streamer.BatchBuffer.Len() > 0 {
-				return true
-			}
-		}
-	}
-}
-
 // TestCaffNodeWaitForFinality is a test that attempts to make sure that the Caff node waits for
-// the derived L1 block to be finalized before updating its record.
+// the derived L1 block to be finalized before advancing its safe head.
 //
 // This tests is designed to evaluate Test 8.2.1 as outlined within the Espresso Celo Integration
 // plan. It has stated task definition as follows:
@@ -127,10 +92,9 @@ func VerifyBatchBufferUpdated(ctx context.Context, streamer *espresso.BatchStrea
 //	Arrange:
 //		Run the sequencer and the Caff node in Espresso mode.
 //	Act:
-//		Wait until the Caff node's batch buffer is empty.
+//		Wait until the Caff node's safe L2 head advances.
 //	Assert:
-//		The Caff node doesn't insert a batch without finalized L1 origin to the batch buffer.
-//		After the L1 origin is finalized, the Caff node inserts the batch.
+//		The Caff node's safe L2 head always has a finalized L1 origin.
 func TestCaffNodeWaitForFinality(t *testing.T) {
 	// Basic test setup.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -153,39 +117,45 @@ func TestCaffNodeWaitForFinality(t *testing.T) {
 	defer env.Stop(t, caffNode)
 
 	l1Client := system.NodeClient(e2esys.RoleL1)
-	rollupClient := system.RollupClient(e2esys.RoleVerif)
-	streamer := caffNode.OpNode.EspressoStreamer()
 
-	initialStatus, err := rollupClient.SyncStatus(context.Background())
+	// Create a RollupClient for the caff node
+	caffRpcClient, err := dial.DialRPCClientWithTimeout(ctx, 30*time.Second, log.New(), caffNode.OpNode.UserRPC().RPC())
 	require.NoError(t, err)
+	caffRollupClient := sources.NewRollupClient(client.NewBaseRPCClient(caffRpcClient))
 
-	// Wait for the batch buffer to be empty which will trigger the Caff node to sync the status
-	// and insert more batches to the buffer.
+	initialStatus, err := caffRollupClient.SyncStatus(ctx)
+	require.NoError(t, err)
+	initialSafeL2 := initialStatus.SafeL2.Number
+
+	// Wait for the Caff node's safe L2 head to advance, and verify that
+	// its L1 origin is always finalized.
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
 	for {
-		if streamer.BatchBuffer.Len() == 0 {
-			// Wait for the finalized L1 number and the batch buffer to be updated.
-			for {
-				if streamer.BatchBuffer.Len() > 0 {
-					// Verify that any batch inserted into the batch buffer has a finalized L1
-					// origin.
-					if !VerifyL1OriginFinalized(t, streamer, l1Client) {
-						require.FailNow(t, "Timeout: L1 origin not finalized")
-					}
-				} else {
-					statusAfterWait, err := rollupClient.SyncStatus(context.Background())
-					require.NoError(t, err)
-					if statusAfterWait.FinalizedL1.Number > initialStatus.FinalizedL1.Number {
-						// Verify that eventually the batch buffer will be updated.
-						if !VerifyBatchBufferUpdated(ctx, streamer) {
-							require.FailNow(t, "Timeout: Batch buffer not updated")
-						}
-						return
-					}
-				}
+		select {
+		case <-ctx.Done():
+			require.FailNow(t, "Timeout: Caff node safe L2 head did not advance")
+		case <-ticker.C:
+			status, err := caffRollupClient.SyncStatus(ctx)
+			require.NoError(t, err)
+
+			// Check that the safe L2 head's L1 origin is finalized
+			safeL2Origin := status.SafeL2.L1Origin
+			finalizedL1, err := l1Client.BlockByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
+			require.NoError(t, err)
+
+			require.LessOrEqual(t, safeL2Origin.Number, finalizedL1.NumberU64(),
+				"Caff node safe L2 head has non-finalized L1 origin: origin=%d, finalized=%d",
+				safeL2Origin.Number, finalizedL1.NumberU64())
+
+			// Test passes once safe L2 head has advanced
+			if status.SafeL2.Number > initialSafeL2 {
+				t.Logf("Caff node safe L2 head advanced from %d to %d with finalized L1 origin %d",
+					initialSafeL2, status.SafeL2.Number, safeL2Origin.Number)
+				return
 			}
 		}
-
-		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -2,7 +2,9 @@ package espresso
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -14,6 +16,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+const BatchBufferCapacity uint64 = 1024
 
 // Espresso light client bindings don't have an explicit name for this struct,
 // so we define it here to avoid spelling it out every time
@@ -90,6 +94,12 @@ type BatchStreamer[B Batch] struct {
 	originHotShotPos uint64
 	// Latest finalized block on the L1.
 	FinalizedL1 eth.L1BlockRef
+	// If the batch buffer is full, but we don't yet have the next batch,
+	// we will start skipping other batches until we encounter the missing batch.
+	// This position will be used to record such a situation occuring, when
+	// we find the target batch HotShot position will be reset to this.
+	skipPos   uint64
+	headBatch *B
 
 	// Maintained in sorted order, but may be missing batches if we receive
 	// any out of order.
@@ -127,13 +137,13 @@ func NewEspressoStreamer[B Batch](
 		// Internally, BatchPos is the position of the batch we are to give out next, hence the +1
 		BatchPos:                      originBatchPos + 1,
 		fallbackBatchPos:              originBatchPos + 1,
-		BatchBuffer:                   NewBatchBuffer[B](),
+		BatchBuffer:                   NewBatchBuffer[B](BatchBufferCapacity),
 		PollingHotShotPollingInterval: pollingHotShotPollingInterval,
-		RemainingBatches:              make(map[common.Hash]B),
 		unmarshalBatch:                unmarshalBatch,
 		originHotShotPos:              originHotShotPos,
 		fallbackHotShotPos:            originHotShotPos,
 		hotShotPos:                    originHotShotPos,
+		skipPos:                       math.MaxUint64,
 	}
 }
 
@@ -181,47 +191,39 @@ func (s *BatchStreamer[B]) Refresh(ctx context.Context, finalizedL1 eth.L1BlockR
 
 // CheckBatch checks the validity of the given batch against the finalized L1
 // block and the safe L1 origin.
-func (s *BatchStreamer[B]) CheckBatch(ctx context.Context, batch B) (BatchValidity, int) {
+func (s *BatchStreamer[B]) CheckBatch(ctx context.Context, batch B) BatchValidity {
 
 	// Make sure the finalized L1 block is initialized before checking the block number.
 	if s.FinalizedL1 == (eth.L1BlockRef{}) {
 		s.Log.Error("Finalized L1 block not initialized")
-		return BatchUndecided, 0
+		return BatchUndecided
 	}
 	origin := (batch).L1Origin()
 
 	if origin.Number > s.FinalizedL1.Number {
 		// Signal to resync to wait for the L1 finality.
 		s.Log.Warn("L1 origin not finalized, pending resync", "finalized L1 block number", s.FinalizedL1.Number, "origin number", origin.Number)
-		return BatchUndecided, 0
+		return BatchUndecided
 	}
 
 	l1headerHash, err := s.RollupL1Client.HeaderHashByNumber(ctx, new(big.Int).SetUint64(origin.Number))
 	if err != nil {
 		// Signal to resync to be able to fetch the L1 header.
 		s.Log.Warn("Failed to fetch the L1 header, pending resync", "error", err)
-		return BatchUndecided, 0
+		return BatchUndecided
 	} else {
 		if l1headerHash != origin.Hash {
 			s.Log.Warn("Dropping batch with invalid L1 origin hash")
-			return BatchDrop, 0
+			return BatchDrop
 		}
 	}
-	// Find a slot to insert the batch
-	i, batchRecorded := s.BatchBuffer.TryInsert(batch)
-
 	// Batch already buffered/finalized
 	if batch.Number() < s.BatchPos {
 		s.Log.Warn("Batch is older than current batchPos, skipping", "batchNr", batch.Number(), "batchPos", s.BatchPos)
-		return BatchPast, 0
+		return BatchPast
 	}
 
-	if batchRecorded {
-		// Duplicate batch found, skip it
-		return BatchPast, i
-	}
-
-	return BatchAccept, i
+	return BatchAccept
 }
 
 // HOTSHOT_BLOCK_STREAM_LIMIT is the maximum number of blocks to attempt to
@@ -298,9 +300,6 @@ func (s *BatchStreamer[B]) Update(ctx context.Context) error {
 			break
 		}
 
-		// Process the remaining batches
-		s.processRemainingBatches(ctx)
-
 		s.Log.Debug("Fetching hotshot blocks", "from", start, "upTo", finish)
 
 		// Process the new batches fetched from Espresso
@@ -342,6 +341,9 @@ func (s *BatchStreamer[B]) fetchHotShotRange(ctx context.Context, start, finish 
 	}
 
 	s.Log.Info("Fetched HotShot block range", "start", start, "finish", finish, "numNamespaceTransactions", len(namespaceRangeTransactions))
+	if len(namespaceRangeTransactions) == 0 {
+		s.Log.Trace("No transactions in hotshot block range", "start", start, "finish", finish)
+	}
 
 	// We want to keep track of the latest block we have processed.
 	// This is essential for ensuring we don't unnecessarily keep
@@ -349,106 +351,71 @@ func (s *BatchStreamer[B]) fetchHotShotRange(ctx context.Context, start, finish 
 	// This should ensure that we keep moving forward and consuming
 	// from the Espresso Blocks without missing any blocks.
 	s.hotShotPos = finish - 1
-	if len(namespaceRangeTransactions) == 0 {
-		s.Log.Trace("No transactions in hotshot block range", "start", start, "finish", finish)
-	}
 
 	for _, namespaceTransaction := range namespaceRangeTransactions {
 		for _, txn := range namespaceTransaction.Transactions {
-			s.processEspressoTransaction(ctx, txn.Payload)
+			err := s.processEspressoTransaction(ctx, txn.Payload)
+			if errors.Is(err, ErrAtCapacity) {
+				s.skipPos = start
+			}
 		}
 	}
 
 	return nil
 }
 
-// processRemainingBatches is a helper method that checks the remaining batches
-// and prunes or adds them to the batch buffer as appropriate.
-func (s *BatchStreamer[B]) processRemainingBatches(ctx context.Context) {
-	// Collect keys to delete, without modifying the batch list during iteration.
-	var keysToDelete []common.Hash
-
-	// Process the remaining batches
-	for k, batch := range s.RemainingBatches {
-		validity, pos := s.CheckBatch(ctx, batch)
-
-		switch validity {
-		case BatchDrop:
-			s.Log.Warn("Dropping batch", "batch", batch)
-			keysToDelete = append(keysToDelete, k)
-			continue
-
-		case BatchPast:
-			s.Log.Warn("Batch already processed. Skipping", "batch", batch)
-			keysToDelete = append(keysToDelete, k)
-			continue
-
-		case BatchUndecided:
-			s.Log.Warn("Batch is still undecided, keeping it in the remaining list", "batch", batch)
-			continue
-
-		case BatchAccept:
-			s.Log.Info("Remaining list", "Recovered batch, inserting batch", batch)
-
-		case BatchFuture:
-			// The function CheckBatch is not expected to return BatchFuture so if we enter this case there is a problem.
-			s.Log.Error("Remaining list", "BatchFuture validity not expected for batch", batch)
-			continue
-		}
-
-		header := batch.Header()
-		s.Log.Trace("Remaining list", "Inserting batch into buffer",
-			"parentHash", header.ParentHash,
-			"epochNum", header.Number,
-			"timestamp", header.Time)
-		s.BatchBuffer.Insert(batch, pos)
-		keysToDelete = append(keysToDelete, k)
-	}
-
-	// Delete keys all at once.
-	for _, k := range keysToDelete {
-		delete(s.RemainingBatches, k)
-	}
-}
-
 // processEspressoTransaction is a helper method that encapsulates the logic of
 // processing batches from the transactions in a block fetched from Espresso.
-func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, transaction espressoCommon.Bytes) {
+// It will return an error if the transaction contains a valid batch, but the buffer is full.
+func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, transaction espressoCommon.Bytes) error {
 	batch, err := s.UnmarshalBatch(transaction)
 	if err != nil {
 		s.Log.Warn("Dropping batch with invalid transaction data", "error", err)
-		return
+		return nil
 	}
 
-	validity, pos := s.CheckBatch(ctx, *batch)
+	validity := s.CheckBatch(ctx, *batch)
 
 	switch validity {
 	case BatchDrop:
 		s.Log.Info("Dropping batch", batch)
+		return nil
 
 	case BatchPast:
 		s.Log.Info("Batch already processed. Skipping", "batch", (*batch).Number())
+		return nil
 
 	case BatchUndecided:
-		hash := (*batch).Hash()
-		if existingBatch, ok := s.RemainingBatches[hash]; ok {
-			s.Log.Warn("Batch already in buffer", "batch", existingBatch)
-		}
-		s.RemainingBatches[hash] = *batch
+		s.Log.Warn("Inserting undecided batch", "batch", (*batch).Hash())
 
 	case BatchAccept:
-		header := (*batch).Header()
-		s.Log.Info("Inserting batch into buffer",
+	}
+
+	header := (*batch).Header()
+
+	// If this is the batch we're supposed to give out next and we don't
+	// have any other candidates, put it in as the head batch
+	if (*batch).Number() == s.BatchPos && s.headBatch == nil {
+		s.Log.Info("Setting batch as the head batch",
+			"hash", (*batch).Hash(),
 			"parentHash", header.ParentHash,
 			"epochNum", header.Number,
 			"timestamp", header.Time)
-		s.BatchBuffer.Insert(*batch, pos)
-
-	case BatchFuture:
-		// The function CheckBatch is not expected to return BatchFuture so if we enter this case there is a problem.
-		s.Log.Error("Remaining list", "BatchFuture validity not expected for batch", batch)
+		s.headBatch = batch
+	} else {
+		// Otherwise, try to buffer it. If the buffer is full, forward the error up to record
+		// that we're skipping batches and will need to revisit when the buffer drains
+		s.Log.Info("Inserting batch into buffer",
+			"hash", (*batch).Hash(),
+			"parentHash", header.ParentHash,
+			"epochNum", header.Number,
+			"timestamp", header.Time)
+		if err := s.BatchBuffer.Insert(*batch); errors.Is(err, ErrAtCapacity) {
+			return err
+		}
 	}
 
+	return nil
 }
 
 // UnmarshalBatch implements EspressoStreamerIFace
@@ -457,7 +424,15 @@ func (s *BatchStreamer[B]) Next(ctx context.Context) *B {
 	if s.HasNext(ctx) {
 		// Current batch is going to be processed, update fallback batch position
 		s.BatchPos += 1
-		return s.BatchBuffer.Pop()
+		head := s.headBatch
+		s.headBatch = nil
+		// If we have been skipping batches, now is the time
+		// to rewind and start considering batches again: we've made more space
+		if s.skipPos != math.MaxUint64 {
+			s.hotShotPos = s.skipPos
+			s.skipPos = math.MaxUint64
+		}
+		return head
 	}
 
 	return nil
@@ -465,10 +440,37 @@ func (s *BatchStreamer[B]) Next(ctx context.Context) *B {
 
 // HasNext implements EspressoStreamerIFace
 func (s *BatchStreamer[B]) HasNext(ctx context.Context) bool {
-	if s.BatchBuffer.Len() > 0 {
-		return (*s.BatchBuffer.Peek()).Number() == s.BatchPos
+	if s.headBatch == nil {
+		nextBuffered := s.BatchBuffer.Peek()
+		if nextBuffered != nil && (*nextBuffered).Number() == s.BatchPos {
+			s.headBatch = nextBuffered
+			s.BatchBuffer.Pop()
+		} else {
+			return false
+		}
 	}
 
+	validity := s.CheckBatch(ctx, *s.headBatch)
+	switch validity {
+	case BatchAccept:
+		// Batch is fine, we can give it out
+		return true
+	case BatchUndecided:
+		// We need to wait for our view of
+		// L1 to update before we can make a
+		// decision
+		return false
+	case BatchDrop:
+		// This was an undecided batch and looks like
+		// an L1 reorg happened that invalidated it.
+		// We drop it.
+		s.headBatch = nil
+		return s.HasNext(ctx)
+	case BatchPast:
+		// This was probably a duplicate batch, skip it
+		s.headBatch = nil
+		return s.HasNext(ctx)
+	}
 	return false
 }
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -437,38 +437,42 @@ func (s *BatchStreamer[B]) Next(ctx context.Context) *B {
 
 // HasNext implements EspressoStreamerIFace
 func (s *BatchStreamer[B]) HasNext(ctx context.Context) bool {
-	if s.headBatch == nil {
-		nextBuffered := s.BatchBuffer.Peek()
-		if nextBuffered != nil && (*nextBuffered).Number() == s.BatchPos {
-			s.headBatch = nextBuffered
-			s.BatchBuffer.Pop()
-		} else {
-			return false
+	for {
+		if s.headBatch == nil {
+			nextBuffered := s.BatchBuffer.Peek()
+			if nextBuffered != nil && (*nextBuffered).Number() == s.BatchPos {
+				s.headBatch = nextBuffered
+				s.BatchBuffer.Pop()
+			} else {
+				return false
+			}
 		}
-	}
 
-	validity := s.CheckBatch(ctx, *s.headBatch)
-	switch validity {
-	case BatchAccept:
-		// Batch is fine, we can give it out
-		return true
-	case BatchUndecided:
-		// We need to wait for our view of
-		// L1 to update before we can make a
-		// decision
+		validity := s.CheckBatch(ctx, *s.headBatch)
+		switch validity {
+		case BatchAccept:
+			// Batch is fine, we can give it out
+			return true
+		case BatchUndecided:
+			// We need to wait for our view of
+			// L1 to update before we can make a
+			// decision
+			return false
+		case BatchDrop:
+			// This was an undecided batch and looks like
+			// an L1 reorg happened that invalidated it.
+			// We drop it and check the next
+			s.headBatch = nil
+			continue
+		case BatchPast:
+			// This was probably a duplicate batch, skip it
+			// and check the next
+			s.headBatch = nil
+			continue
+		}
+
 		return false
-	case BatchDrop:
-		// This was an undecided batch and looks like
-		// an L1 reorg happened that invalidated it.
-		// We drop it.
-		s.headBatch = nil
-		return s.HasNext(ctx)
-	case BatchPast:
-		// This was probably a duplicate batch, skip it
-		s.headBatch = nil
-		return s.HasNext(ctx)
 	}
-	return false
 }
 
 // This function allows to "pin" the Espresso block height that is guaranteed not to contain

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -96,7 +96,7 @@ type BatchStreamer[B Batch] struct {
 	FinalizedL1 eth.L1BlockRef
 	// If the batch buffer is full, but we don't yet have the next batch,
 	// we will start skipping other batches until we encounter the missing batch.
-	// This position will be used to record such a situation occuring, when
+	// This position will be used to record such a situation occurring, when
 	// we find the target batch HotShot position will be reset to this.
 	skipPos   uint64
 	headBatch *B

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -407,7 +407,11 @@ func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, trans
 			"parentHash", header.ParentHash,
 			"epochNum", header.Number,
 			"timestamp", header.Time)
-		if err := s.BatchBuffer.Insert(*batch); errors.Is(err, ErrAtCapacity) {
+		err := s.BatchBuffer.Insert(*batch)
+		if errors.Is(err, ErrDuplicateBatch) {
+			s.Log.Warn("Dropping batch with duplicate hash")
+		}
+		if errors.Is(err, ErrAtCapacity) {
 			return err
 		}
 	}

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -353,7 +353,7 @@ func (s *BatchStreamer[B]) fetchHotShotRange(ctx context.Context, start, finish 
 		for _, txn := range namespaceTransaction.Transactions {
 			err := s.processEspressoTransaction(ctx, txn.Payload)
 			if errors.Is(err, ErrAtCapacity) {
-				s.skipPos = start
+				s.skipPos = min(s.skipPos, start)
 			}
 		}
 	}

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -105,9 +105,6 @@ type BatchStreamer[B Batch] struct {
 	// any out of order.
 	BatchBuffer BatchBuffer[B]
 
-	// Manage the batches which origin is unfinalized
-	RemainingBatches map[common.Hash]B
-
 	unmarshalBatch func([]byte) (*B, error)
 }
 

--- a/espresso/streamer_test.go
+++ b/espresso/streamer_test.go
@@ -414,27 +414,9 @@ func setupStreamerTesting(namespace uint64, batcherAddress common.Address) (*Moc
 // containing the provided number of transactions.
 // It is generated using a random number generator to create the transactions
 // contained within.  Everything else is derived from the provided parameters
-// for repeatability.
+// for repeatability. Uses m.FinalizedL1 as the L1 origin.
 func (m *MockStreamerSource) createSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int, l2Height uint64) *derive.SingularBatch {
-	signer := geth_types.NewLondonSigner(chainID)
-	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
-	txsEncoded := make([]hexutil.Bytes, 0, txCount)
-	for i := 0; i < txCount; i++ {
-		tx := testutils.RandomTx(rng, baseFee, signer)
-		txEncoded, err := tx.MarshalBinary()
-		if err != nil {
-			panic("tx Marshal binary" + err.Error())
-		}
-		txsEncoded = append(txsEncoded, txEncoded)
-	}
-
-	return &derive.SingularBatch{
-		ParentHash:   createHashFromHeight(l2Height),
-		EpochNum:     rollup.Epoch(m.FinalizedL1.Number),
-		EpochHash:    m.FinalizedL1.Hash,
-		Timestamp:    l2Height,
-		Transactions: txsEncoded,
-	}
+	return m.createSingularBatchWithL1Origin(rng, txCount, chainID, l2Height, m.FinalizedL1.Number, m.FinalizedL1.Hash)
 }
 
 // createEspressoBatch creates a mock EspressoBatch for testing purposes
@@ -473,6 +455,7 @@ func createTransactionsInBlock(tx *espressoCommon.Transaction) espressoClient.Tr
 // for testing purposes. It generates a test SingularBatch, and takes it
 // through the steps of getting all the way to an Espresso transaction in block.
 // Every intermediate step is returned for inspection / utilization in tests.
+// Uses m.FinalizedL1 as the L1 origin.
 func (m *MockStreamerSource) CreateEspressoTxnData(
 	ctx context.Context,
 	namespace uint64,
@@ -481,13 +464,7 @@ func (m *MockStreamerSource) CreateEspressoTxnData(
 	l2Height uint64,
 	chainSigner crypto.ChainSigner,
 ) (*derive.SingularBatch, *derive.EspressoBatch, *espressoCommon.Transaction, espressoClient.TransactionsInBlock) {
-	txCount := rng.Intn(10)
-	batch := m.createSingularBatch(rng, txCount, chainID, l2Height)
-	espBatch := createEspressoBatch(batch)
-	espTxn := createEspressoTransaction(ctx, espBatch, namespace, chainSigner)
-	espTxnInBlock := createTransactionsInBlock(espTxn)
-
-	return batch, espBatch, espTxn, espTxnInBlock
+	return m.CreateEspressoTxnDataWithL1Origin(ctx, namespace, rng, chainID, l2Height, chainSigner, m.FinalizedL1.Number, m.FinalizedL1.Hash)
 }
 
 // TestStreamerSmoke tests the basic functionality of the EspressoStreamer
@@ -802,4 +779,556 @@ func TestEspressoStreamerDuplicationHandling(t *testing.T) {
 
 	// Check that the state has the correct number of duplicated batches
 	require.Equal(t, len(state.EspTransactionData), 2*N)
+}
+
+// createSingularBatchWithL1Origin creates a mock SingularBatch for testing purposes
+// with a specific L1 origin (epoch number and hash).
+func (m *MockStreamerSource) createSingularBatchWithL1Origin(rng *rand.Rand, txCount int, chainID *big.Int, l2Height uint64, epochNum uint64, epochHash common.Hash) *derive.SingularBatch {
+	signer := geth_types.NewLondonSigner(chainID)
+	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
+	txsEncoded := make([]hexutil.Bytes, 0, txCount)
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, baseFee, signer)
+		txEncoded, err := tx.MarshalBinary()
+		if err != nil {
+			panic("tx Marshal binary" + err.Error())
+		}
+		txsEncoded = append(txsEncoded, txEncoded)
+	}
+
+	return &derive.SingularBatch{
+		ParentHash:   createHashFromHeight(l2Height),
+		EpochNum:     rollup.Epoch(epochNum),
+		EpochHash:    epochHash,
+		Timestamp:    l2Height,
+		Transactions: txsEncoded,
+	}
+}
+
+// CreateEspressoTxnDataWithL1Origin creates a mock Espresso transaction data set
+// for testing purposes with a specific L1 origin.
+func (m *MockStreamerSource) CreateEspressoTxnDataWithL1Origin(
+	ctx context.Context,
+	namespace uint64,
+	rng *rand.Rand,
+	chainID *big.Int,
+	l2Height uint64,
+	chainSigner crypto.ChainSigner,
+	epochNum uint64,
+	epochHash common.Hash,
+) (*derive.SingularBatch, *derive.EspressoBatch, *espressoCommon.Transaction, espressoClient.TransactionsInBlock) {
+	txCount := rng.Intn(10)
+	batch := m.createSingularBatchWithL1Origin(rng, txCount, chainID, l2Height, epochNum, epochHash)
+	espBatch := createEspressoBatch(batch)
+	espTxn := createEspressoTransaction(ctx, espBatch, namespace, chainSigner)
+	espTxnInBlock := createTransactionsInBlock(espTxn)
+
+	return batch, espBatch, espTxn, espTxnInBlock
+}
+
+// TestStreamerHeadBatchHandling tests the headBatch direct assignment and buffer promotion behavior.
+func TestStreamerHeadBatchHandling(t *testing.T) {
+	namespace := uint64(42)
+	chainID := big.NewInt(int64(namespace))
+	privateKeyString := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
+	chainSigner := chainSignerFactory(chainID, common.Address{})
+
+	t.Run("batch matching BatchPos assigned directly to headBatch when headBatch is nil", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(0))
+
+		// Refresh state - after this, BatchPos becomes 1 (fallbackBatchPos=0, BatchPos=0+1=1)
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Create batch with number matching BatchPos (which is 1 after Refresh with SafeL2.Number=0)
+		_, _, _, espTxnInBlock := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
+		state.AddEspressoTransactionData(0, namespace, espTxnInBlock)
+
+		// Update to fetch the batch
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// The batch should be assigned directly to headBatch
+		require.True(t, streamer.HasNext(ctx), "batch should be available")
+
+		// Next should return the batch
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+	})
+
+	t.Run("HasNext promotes batch from buffer when headBatch is nil", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(1))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Create batch 2 first (goes to buffer since it's ahead of BatchPos=1)
+		_, _, _, espTxnInBlock2 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 2, chainSigner)
+		state.AddEspressoTransactionData(0, namespace, espTxnInBlock2)
+
+		// Create batch 1 (becomes headBatch)
+		_, _, _, espTxnInBlock1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
+		state.AddEspressoTransactionData(1, namespace, espTxnInBlock1)
+
+		// Update to fetch both batches
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// Consume batch 1
+		require.True(t, streamer.HasNext(ctx))
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+
+		// Now BatchPos is 2, and batch 2 should be promoted from buffer
+		require.True(t, streamer.HasNext(ctx), "batch 2 should be promoted from buffer")
+		batch = streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(2), batch.Number())
+	})
+
+	t.Run("invalid headBatch is discarded and next candidate promoted from buffer", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(2))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Create batch 1 with INVALID L1 origin hash (using a hash that won't match)
+		invalidHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		_, _, _, espTxnInBlockInvalid := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, invalidHash,
+		)
+		state.AddEspressoTransactionData(0, namespace, espTxnInBlockInvalid)
+
+		// Create batch 1 with VALID L1 origin (using the correct hash)
+		_, _, _, espTxnInBlockValid := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, state.FinalizedL1.Hash,
+		)
+		state.AddEspressoTransactionData(1, namespace, espTxnInBlockValid)
+
+		// Update to fetch both batches
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should drop the invalid batch and find the valid one
+		require.True(t, streamer.HasNext(ctx), "valid batch should be available after invalid is dropped")
+
+		// Next should return the valid batch
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+	})
+}
+
+// TestStreamerMultipleBatchesSameNumber tests handling of multiple batches with
+// the same batch number but different validity.
+func TestStreamerMultipleBatchesSameNumber(t *testing.T) {
+	namespace := uint64(42)
+	chainID := big.NewInt(int64(namespace))
+	privateKeyString := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
+	chainSigner := chainSignerFactory(chainID, common.Address{})
+
+	t.Run("invalid batches dropped during HasNext iteration until valid found", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(3))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		invalidHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+		// Create 3 batches all with number 1:
+		// Batch A: invalid L1 origin hash
+		_, _, _, espTxnA := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, invalidHash,
+		)
+		state.AddEspressoTransactionData(0, namespace, espTxnA)
+
+		// Batch B: invalid L1 origin hash
+		_, _, _, espTxnB := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, invalidHash,
+		)
+		state.AddEspressoTransactionData(1, namespace, espTxnB)
+
+		// Batch C: valid L1 origin hash
+		_, _, _, espTxnC := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, state.FinalizedL1.Hash,
+		)
+		state.AddEspressoTransactionData(2, namespace, espTxnC)
+
+		// Update to fetch all batches
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should return true (found valid batch C)
+		require.True(t, streamer.HasNext(ctx))
+
+		// Next should return batch C (the valid one)
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+
+		// BatchPos should have advanced to 2
+		require.Equal(t, uint64(2), streamer.BatchPos)
+	})
+
+	t.Run("BatchPos does NOT advance when all candidates for batch number are invalid", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(4))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		invalidHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+		// Create 3 batches all with number 1, ALL with invalid L1 origins
+		for i := 0; i < 3; i++ {
+			_, _, _, espTxn := state.CreateEspressoTxnDataWithL1Origin(
+				ctx, namespace, rng, chainID, 1, chainSigner,
+				state.FinalizedL1.Number, invalidHash,
+			)
+			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
+		}
+
+		// Update to fetch all batches
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// All candidates should be dropped (BatchDrop)
+		// HasNext should return false (no valid batch available)
+		require.False(t, streamer.HasNext(ctx))
+
+		// BatchPos should still be 1 (NOT advanced)
+		require.Equal(t, uint64(1), streamer.BatchPos)
+	})
+
+	t.Run("first valid batch returned when multiple valid candidates exist", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(5))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Create 2 valid batches for number 1 with different hashes
+		_, espBatch1, _, espTxn1 := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, state.FinalizedL1.Hash,
+		)
+		state.AddEspressoTransactionData(0, namespace, espTxn1)
+		firstBatchHash := espBatch1.Hash()
+
+		_, _, _, espTxn2 := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, state.FinalizedL1.Hash,
+		)
+		state.AddEspressoTransactionData(1, namespace, espTxn2)
+
+		// Update to fetch both batches
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should return true
+		require.True(t, streamer.HasNext(ctx))
+
+		// Next should return the first valid batch (insertion order matters)
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+		require.Equal(t, firstBatchHash, batch.Hash(), "first inserted batch should be returned")
+
+		// Second batch should be skipped as BatchPast
+		require.False(t, streamer.HasNext(ctx), "no more batches should be available")
+	})
+}
+
+// TestStreamerBufferCapacityAndSkipPos tests the skip position mechanism when the buffer fills up.
+func TestStreamerBufferCapacityAndSkipPos(t *testing.T) {
+	namespace := uint64(42)
+	chainID := big.NewInt(int64(namespace))
+	privateKeyString := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
+	chainSigner := chainSignerFactory(chainID, common.Address{})
+
+	t.Run("skipPos set and rewind after Next drains buffer", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state := NewMockStreamerSource()
+		logger := new(NoOpLogger)
+
+		// Create streamer - after Refresh with SafeL2.Number=0, BatchPos becomes 1
+		streamer := espresso.NewEspressoStreamer(
+			namespace,
+			state,
+			state,
+			state,
+			state,
+			logger,
+			derive.CreateEspressoBatchUnmarshaler(signerAddress),
+			50*time.Millisecond,
+			0,
+			0, // originBatchPos=0, so BatchPos starts at 1
+		)
+
+		rng := rand.New(rand.NewSource(6))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Fill the buffer with out-of-order batches (batches 2, 3, 4, ... exceeding capacity)
+		// We need batch 1 to be missing initially to fill the buffer
+		for i := 0; i < int(espresso.BatchBufferCapacity)+5; i++ {
+			// Create batches starting from 2 (skipping 1)
+			_, _, _, espTxn := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, uint64(i+2), chainSigner)
+			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
+		}
+
+		// Update - this should fill buffer and set skipPos
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should return false (batch 1 is missing)
+		require.False(t, streamer.HasNext(ctx))
+
+		// Now add batch 1 at a later hotshot position
+		laterHotshotPos := uint64(espresso.BatchBufferCapacity + 10)
+		_, _, _, espTxn1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
+		state.AddEspressoTransactionData(laterHotshotPos, namespace, espTxn1)
+
+		// Update again to fetch batch 1
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// Now HasNext should return true
+		require.True(t, streamer.HasNext(ctx))
+
+		// Consume batch 1
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+
+		// After consuming, the streamer should have rewound to re-fetch skipped batches
+		// We should be able to get batch 2 now
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		require.True(t, streamer.HasNext(ctx))
+		batch = streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(2), batch.Number())
+	})
+
+	t.Run("new batch for current BatchPos arrives when buffer full", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state := NewMockStreamerSource()
+		logger := new(NoOpLogger)
+
+		// Create streamer - after Refresh with SafeL2.Number=0, BatchPos becomes 1
+		streamer := espresso.NewEspressoStreamer(
+			namespace,
+			state,
+			state,
+			state,
+			state,
+			logger,
+			derive.CreateEspressoBatchUnmarshaler(signerAddress),
+			50*time.Millisecond,
+			0,
+			0, // originBatchPos=0, so BatchPos starts at 1
+		)
+
+		rng := rand.New(rand.NewSource(7))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Fill buffer with future batches (2, 3, 4, ...)
+		for i := 0; i < int(espresso.BatchBufferCapacity); i++ {
+			_, _, _, espTxn := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, uint64(i+2), chainSigner)
+			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
+		}
+
+		// Update to fill buffer
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should be false (batch 1 is missing)
+		require.False(t, streamer.HasNext(ctx))
+
+		// Now add batch 1 (the one we need)
+		laterPos := uint64(espresso.BatchBufferCapacity + 1)
+		_, _, _, espTxn1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
+		state.AddEspressoTransactionData(laterPos, namespace, espTxn1)
+
+		// Update to get batch 1
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// Batch 1 should be assigned to headBatch directly (not buffered)
+		require.True(t, streamer.HasNext(ctx))
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+	})
+}
+
+// TestStreamerBatchOrderingDeterminism tests that the streamer processes batches
+// deterministically when multiple batches have the same number - insertion order
+// must be respected.
+func TestStreamerBatchOrderingDeterminism(t *testing.T) {
+	namespace := uint64(42)
+	chainID := big.NewInt(int64(namespace))
+	privateKeyString := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
+	chainSigner := chainSignerFactory(chainID, common.Address{})
+
+	t.Run("must wait for first-inserted batch to become decided before processing later ones", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(8))
+
+		// Advance L1 to have two finalized blocks at heights 1 and 2
+		// FinalizedL1 starts at 1
+		state.AdvanceFinalizedL1() // Now at 2
+
+		// Refresh state with only height 1 finalized (we'll pretend height 2 is not finalized yet)
+		// We need to control what the streamer sees as finalized
+		// After this refresh, BatchPos becomes 1
+		l1Height1 := createL1BlockRef(1)
+		err := streamer.Refresh(ctx, l1Height1, state.SafeL2.Number, state.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Insert batch a1 (number 1, L1 origin at height 2 - NOT finalized yet)
+		l1Height2 := createL1BlockRef(2)
+		_, espBatchA1, _, espTxnA1 := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			l1Height2.Number, l1Height2.Hash,
+		)
+		state.AddEspressoTransactionData(0, namespace, espTxnA1)
+		a1Hash := espBatchA1.Hash()
+
+		// Insert batch a2 (number 1, L1 origin at height 1 - IS finalized)
+		_, _, _, espTxnA2 := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			l1Height1.Number, l1Height1.Hash,
+		)
+		state.AddEspressoTransactionData(1, namespace, espTxnA2)
+
+		// Update to fetch both batches
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should return false - must wait for a1 (inserted first) to become decided
+		// even though a2 is already valid
+		require.False(t, streamer.HasNext(ctx), "should wait for first-inserted batch to become decided")
+
+		// Now advance L1 finalized to height 2
+		err = streamer.Refresh(ctx, l1Height2, state.SafeL2.Number, state.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// HasNext should now return true
+		require.True(t, streamer.HasNext(ctx))
+
+		// Next should return a1 (the first-inserted batch)
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+		require.Equal(t, a1Hash, batch.Hash(), "first-inserted batch should be returned")
+
+		// a2 should subsequently be skipped as BatchPast
+		require.False(t, streamer.HasNext(ctx), "second batch should be skipped")
+	})
+
+	t.Run("insertion order respected across multiple Update calls", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state, streamer := setupStreamerTesting(namespace, signerAddress)
+		rng := rand.New(rand.NewSource(9))
+
+		// Refresh state - after this, BatchPos becomes 1
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// First Update: insert batch a1 (number 1)
+		_, espBatchA1, _, espTxnA1 := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, state.FinalizedL1.Hash,
+		)
+		state.AddEspressoTransactionData(0, namespace, espTxnA1)
+		a1Hash := espBatchA1.Hash()
+
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// Second Update: insert batch a2 (number 1, different hash)
+		_, _, _, espTxnA2 := state.CreateEspressoTxnDataWithL1Origin(
+			ctx, namespace, rng, chainID, 1, chainSigner,
+			state.FinalizedL1.Number, state.FinalizedL1.Hash,
+		)
+		state.AddEspressoTransactionData(1, namespace, espTxnA2)
+
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+
+		// HasNext should return true
+		require.True(t, streamer.HasNext(ctx))
+
+		// Next should return a1 (first inserted)
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, a1Hash, batch.Hash(), "first-inserted batch should be returned")
+
+		// a2 should be skipped as BatchPast
+		require.False(t, streamer.HasNext(ctx))
+	})
 }

--- a/espresso/streamer_test.go
+++ b/espresso/streamer_test.go
@@ -1080,6 +1080,96 @@ func TestStreamerBufferCapacityAndSkipPos(t *testing.T) {
 	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
 	chainSigner := chainSignerFactory(chainID, common.Address{})
 
+	t.Run("skipPos not overwritten across multiple fetch ranges", func(t *testing.T) {
+		// Regression test: when the Update loop iterates through multiple
+		// HotShot block ranges, hitting ErrAtCapacity in a later range must
+		// NOT overwrite skipPos set by an earlier range. Otherwise the rewind
+		// skips the earlier range's batches permanently.
+		//
+		// Scenario:
+		//   - Enough batches (starting from 2, skipping 1) are placed to fill
+		//     the buffer, plus an extra fetch range worth of batches beyond it.
+		//   - The extra batches are dropped because the buffer is full.
+		//     skipPos should record the earliest range where capacity was hit.
+		//   - Batch 1 is injected later, consumed, and triggers a rewind.
+		//   - After draining the buffer, the next batch must come from the
+		//     re-fetched overflow. If skipPos was overwritten to a later range
+		//     start, the rewind won't go far enough and those batches are lost.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		state := NewMockStreamerSource()
+		logger := new(NoOpLogger)
+
+		streamer := espresso.NewEspressoStreamer(
+			namespace,
+			state,
+			state,
+			state,
+			state,
+			logger,
+			derive.CreateEspressoBatchUnmarshaler(signerAddress),
+			50*time.Millisecond,
+			0,
+			0, // originBatchPos=0, so BatchPos starts at 1
+		)
+
+		rng := rand.New(rand.NewSource(99))
+
+		syncStatus := state.SyncStatus()
+		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+		require.NoError(t, err)
+
+		// Place enough batches to fill the buffer and overflow by one full
+		// fetch range. Batch 1 is intentionally missing so HasNext stays
+		// false, forcing the Update loop to keep iterating across ranges.
+		totalBatches := int(espresso.BatchBufferCapacity) + int(espresso.HOTSHOT_BLOCK_FETCH_LIMIT)
+		for i := 0; i < totalBatches; i++ {
+			_, _, _, espTxn := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, uint64(i+2), chainSigner)
+			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
+		}
+
+		// Update processes all ranges. The buffer fills up partway through,
+		// and all subsequent batches are dropped with ErrAtCapacity.
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+		require.False(t, streamer.HasNext(ctx))
+
+		// Inject batch 1 beyond all existing data.
+		batch1Pos := uint64(totalBatches + 10)
+		_, _, _, espTxn1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
+		state.AddEspressoTransactionData(batch1Pos, namespace, espTxn1)
+
+		// Fetch and consume batch 1 — triggers the rewind via skipPos.
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+		require.True(t, streamer.HasNext(ctx))
+		batch := streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, uint64(1), batch.Number())
+
+		// Drain the entire buffer of previously-buffered batches.
+		firstOverflow := uint64(espresso.BatchBufferCapacity) + 2
+		for expectedNum := uint64(2); expectedNum < firstOverflow; expectedNum++ {
+			err = streamer.Update(ctx)
+			require.NoError(t, err)
+			require.True(t, streamer.HasNext(ctx), "expected batch %d to be available", expectedNum)
+			batch = streamer.Next(ctx)
+			require.NotNil(t, batch)
+			require.Equal(t, expectedNum, batch.Number())
+		}
+
+		// The first batch that was dropped due to capacity must now be
+		// recoverable via the rewind. If skipPos was overwritten to a later
+		// range, this batch is permanently lost.
+		err = streamer.Update(ctx)
+		require.NoError(t, err)
+		require.True(t, streamer.HasNext(ctx), "first overflow batch must be available after rewind — skipPos must preserve the earliest range")
+		batch = streamer.Next(ctx)
+		require.NotNil(t, batch)
+		require.Equal(t, firstOverflow, batch.Number(), "first batch after buffer drain must not be skipped")
+	})
+
 	t.Run("skipPos set and rewind after Next drains buffer", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/espresso/streamer_test.go
+++ b/espresso/streamer_test.go
@@ -410,15 +410,6 @@ func setupStreamerTesting(namespace uint64, batcherAddress common.Address) (*Moc
 	return state, streamer
 }
 
-// createSingularBatch creates a mock SingularBatch for testing purposes
-// containing the provided number of transactions.
-// It is generated using a random number generator to create the transactions
-// contained within.  Everything else is derived from the provided parameters
-// for repeatability. Uses m.FinalizedL1 as the L1 origin.
-func (m *MockStreamerSource) createSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int, l2Height uint64) *derive.SingularBatch {
-	return m.createSingularBatchWithL1Origin(rng, txCount, chainID, l2Height, m.FinalizedL1.Number, m.FinalizedL1.Hash)
-}
-
 // createEspressoBatch creates a mock EspressoBatch for testing purposes
 // containing the provided SingularBatch.
 func createEspressoBatch(batch *derive.SingularBatch) *derive.EspressoBatch {
@@ -781,9 +772,9 @@ func TestEspressoStreamerDuplicationHandling(t *testing.T) {
 	require.Equal(t, len(state.EspTransactionData), 2*N)
 }
 
-// createSingularBatchWithL1Origin creates a mock SingularBatch for testing purposes
+// createSingularBatch creates a mock SingularBatch for testing purposes
 // with a specific L1 origin (epoch number and hash).
-func (m *MockStreamerSource) createSingularBatchWithL1Origin(rng *rand.Rand, txCount int, chainID *big.Int, l2Height uint64, epochNum uint64, epochHash common.Hash) *derive.SingularBatch {
+func (m *MockStreamerSource) createSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int, l2Height uint64, epochNum uint64, epochHash common.Hash) *derive.SingularBatch {
 	signer := geth_types.NewLondonSigner(chainID)
 	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
 	txsEncoded := make([]hexutil.Bytes, 0, txCount)
@@ -818,7 +809,7 @@ func (m *MockStreamerSource) CreateEspressoTxnDataWithL1Origin(
 	epochHash common.Hash,
 ) (*derive.SingularBatch, *derive.EspressoBatch, *espressoCommon.Transaction, espressoClient.TransactionsInBlock) {
 	txCount := rng.Intn(10)
-	batch := m.createSingularBatchWithL1Origin(rng, txCount, chainID, l2Height, epochNum, epochHash)
+	batch := m.createSingularBatch(rng, txCount, chainID, l2Height, epochNum, epochHash)
 	espBatch := createEspressoBatch(batch)
 	espTxn := createEspressoTransaction(ctx, espBatch, namespace, chainSigner)
 	espTxnInBlock := createTransactionsInBlock(espTxn)

--- a/espresso/streamer_test.go
+++ b/espresso/streamer_test.go
@@ -817,119 +817,52 @@ func (m *MockStreamerSource) CreateEspressoTxnDataWithL1Origin(
 	return batch, espBatch, espTxn, espTxnInBlock
 }
 
-// TestStreamerHeadBatchHandling tests the headBatch direct assignment and buffer promotion behavior.
-func TestStreamerHeadBatchHandling(t *testing.T) {
+// TestStreamerInvalidHeadBatchDiscarded tests that an invalid headBatch is discarded
+// and the next valid candidate is promoted from the buffer.
+func TestStreamerInvalidHeadBatchDiscarded(t *testing.T) {
 	namespace := uint64(42)
 	chainID := big.NewInt(int64(namespace))
 	privateKeyString := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
 	chainSigner := chainSignerFactory(chainID, common.Address{})
 
-	t.Run("batch matching BatchPos assigned directly to headBatch when headBatch is nil", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-		state, streamer := setupStreamerTesting(namespace, signerAddress)
-		rng := rand.New(rand.NewSource(0))
+	state, streamer := setupStreamerTesting(namespace, signerAddress)
+	rng := rand.New(rand.NewSource(2))
 
-		// Refresh state - after this, BatchPos becomes 1 (fallbackBatchPos=0, BatchPos=0+1=1)
-		syncStatus := state.SyncStatus()
-		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
-		require.NoError(t, err)
+	// Refresh state - after this, BatchPos becomes 1
+	syncStatus := state.SyncStatus()
+	err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
+	require.NoError(t, err)
 
-		// Create batch with number matching BatchPos (which is 1 after Refresh with SafeL2.Number=0)
-		_, _, _, espTxnInBlock := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
-		state.AddEspressoTransactionData(0, namespace, espTxnInBlock)
+	// Create batch 1 with INVALID L1 origin hash (using a hash that won't match)
+	invalidHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, _, _, espTxnInBlockInvalid := state.CreateEspressoTxnDataWithL1Origin(
+		ctx, namespace, rng, chainID, 1, chainSigner,
+		state.FinalizedL1.Number, invalidHash,
+	)
+	state.AddEspressoTransactionData(0, namespace, espTxnInBlockInvalid)
 
-		// Update to fetch the batch
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
+	// Create batch 1 with VALID L1 origin (using the correct hash)
+	_, _, _, espTxnInBlockValid := state.CreateEspressoTxnDataWithL1Origin(
+		ctx, namespace, rng, chainID, 1, chainSigner,
+		state.FinalizedL1.Number, state.FinalizedL1.Hash,
+	)
+	state.AddEspressoTransactionData(1, namespace, espTxnInBlockValid)
 
-		// The batch should be assigned directly to headBatch
-		require.True(t, streamer.HasNext(ctx), "batch should be available")
+	// Update to fetch both batches
+	err = streamer.Update(ctx)
+	require.NoError(t, err)
 
-		// Next should return the batch
-		batch := streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(1), batch.Number())
-	})
+	// HasNext should drop the invalid batch and find the valid one
+	require.True(t, streamer.HasNext(ctx), "valid batch should be available after invalid is dropped")
 
-	t.Run("HasNext promotes batch from buffer when headBatch is nil", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		state, streamer := setupStreamerTesting(namespace, signerAddress)
-		rng := rand.New(rand.NewSource(1))
-
-		// Refresh state - after this, BatchPos becomes 1
-		syncStatus := state.SyncStatus()
-		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
-		require.NoError(t, err)
-
-		// Create batch 2 first (goes to buffer since it's ahead of BatchPos=1)
-		_, _, _, espTxnInBlock2 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 2, chainSigner)
-		state.AddEspressoTransactionData(0, namespace, espTxnInBlock2)
-
-		// Create batch 1 (becomes headBatch)
-		_, _, _, espTxnInBlock1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
-		state.AddEspressoTransactionData(1, namespace, espTxnInBlock1)
-
-		// Update to fetch both batches
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-
-		// Consume batch 1
-		require.True(t, streamer.HasNext(ctx))
-		batch := streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(1), batch.Number())
-
-		// Now BatchPos is 2, and batch 2 should be promoted from buffer
-		require.True(t, streamer.HasNext(ctx), "batch 2 should be promoted from buffer")
-		batch = streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(2), batch.Number())
-	})
-
-	t.Run("invalid headBatch is discarded and next candidate promoted from buffer", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		state, streamer := setupStreamerTesting(namespace, signerAddress)
-		rng := rand.New(rand.NewSource(2))
-
-		// Refresh state - after this, BatchPos becomes 1
-		syncStatus := state.SyncStatus()
-		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
-		require.NoError(t, err)
-
-		// Create batch 1 with INVALID L1 origin hash (using a hash that won't match)
-		invalidHash := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
-		_, _, _, espTxnInBlockInvalid := state.CreateEspressoTxnDataWithL1Origin(
-			ctx, namespace, rng, chainID, 1, chainSigner,
-			state.FinalizedL1.Number, invalidHash,
-		)
-		state.AddEspressoTransactionData(0, namespace, espTxnInBlockInvalid)
-
-		// Create batch 1 with VALID L1 origin (using the correct hash)
-		_, _, _, espTxnInBlockValid := state.CreateEspressoTxnDataWithL1Origin(
-			ctx, namespace, rng, chainID, 1, chainSigner,
-			state.FinalizedL1.Number, state.FinalizedL1.Hash,
-		)
-		state.AddEspressoTransactionData(1, namespace, espTxnInBlockValid)
-
-		// Update to fetch both batches
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-
-		// HasNext should drop the invalid batch and find the valid one
-		require.True(t, streamer.HasNext(ctx), "valid batch should be available after invalid is dropped")
-
-		// Next should return the valid batch
-		batch := streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(1), batch.Number())
-	})
+	// Next should return the valid batch
+	batch := streamer.Next(ctx)
+	require.NotNil(t, batch)
+	require.Equal(t, uint64(1), batch.Number())
 }
 
 // TestStreamerMultipleBatchesSameNumber tests handling of multiple batches with
@@ -1168,77 +1101,6 @@ func TestStreamerBufferCapacityAndSkipPos(t *testing.T) {
 		batch = streamer.Next(ctx)
 		require.NotNil(t, batch)
 		require.Equal(t, firstOverflow, batch.Number(), "first batch after buffer drain must not be skipped")
-	})
-
-	t.Run("skipPos set and rewind after Next drains buffer", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		state := NewMockStreamerSource()
-		logger := new(NoOpLogger)
-
-		// Create streamer - after Refresh with SafeL2.Number=0, BatchPos becomes 1
-		streamer := espresso.NewEspressoStreamer(
-			namespace,
-			state,
-			state,
-			state,
-			state,
-			logger,
-			derive.CreateEspressoBatchUnmarshaler(signerAddress),
-			50*time.Millisecond,
-			0,
-			0, // originBatchPos=0, so BatchPos starts at 1
-		)
-
-		rng := rand.New(rand.NewSource(6))
-
-		// Refresh state - after this, BatchPos becomes 1
-		syncStatus := state.SyncStatus()
-		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
-		require.NoError(t, err)
-
-		// Fill the buffer with out-of-order batches (batches 2, 3, 4, ... exceeding capacity)
-		// We need batch 1 to be missing initially to fill the buffer
-		for i := 0; i < int(espresso.BatchBufferCapacity)+5; i++ {
-			// Create batches starting from 2 (skipping 1)
-			_, _, _, espTxn := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, uint64(i+2), chainSigner)
-			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
-		}
-
-		// Update - this should fill buffer and set skipPos
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-
-		// HasNext should return false (batch 1 is missing)
-		require.False(t, streamer.HasNext(ctx))
-
-		// Now add batch 1 at a later hotshot position
-		laterHotshotPos := uint64(espresso.BatchBufferCapacity + 10)
-		_, _, _, espTxn1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
-		state.AddEspressoTransactionData(laterHotshotPos, namespace, espTxn1)
-
-		// Update again to fetch batch 1
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-
-		// Now HasNext should return true
-		require.True(t, streamer.HasNext(ctx))
-
-		// Consume batch 1
-		batch := streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(1), batch.Number())
-
-		// After consuming, the streamer should have rewound to re-fetch skipped batches
-		// We should be able to get batch 2 now
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-
-		require.True(t, streamer.HasNext(ctx))
-		batch = streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(2), batch.Number())
 	})
 
 	t.Run("new batch for current BatchPos arrives when buffer full", func(t *testing.T) {


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
- Limits batch buffer capacity
- Introduces headBatch field in streamer to avoid getting stuck if batch buffer is completely filled with future batches
- Puts undecided batches into the same queue as decided to avoid time-based non-determinism

### This PR does not:


### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->
<!-- [ ] For integration projects, make sure it won't break backward compatibility. -->

<!-- Details on maintaining backward compatibility for integration projects: -->
<!-- * Try to keep changes additive: add new, optional methods, flags, or parameters instead of modifying or removing existing functionality. -->
<!-- * If modification is necessary, it should be either a clear bug fix or guarded by a config/feature flag.  -->
<!-- * Follow Open Closed Principle and Interface Segregation Principle, clients should not be forced to depend on interfaces they do not use. -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
