### PR TITLE
Increase Attestation Proof Generation Timeout

### DIFF
--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -1032,7 +1032,7 @@ func (l *BatchSubmitter) GenerateZKProof(ctx context.Context, attestationBytes [
 
 	request.Header.Set("Content-Type", "application/octet-stream")
 	client := http.Client{
-		Timeout: 2 * time.Minute,
+		Timeout: 3 * time.Minute,
 	}
 	res, err := client.Do(request)
 	if err != nil {

--- a/op-batcher/batcher/espresso.go
+++ b/op-batcher/batcher/espresso.go
@@ -1032,7 +1032,7 @@ func (l *BatchSubmitter) GenerateZKProof(ctx context.Context, attestationBytes [
 
 	request.Header.Set("Content-Type", "application/octet-stream")
 	client := http.Client{
-		Timeout: 3 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 	res, err := client.Do(request)
 	if err != nil {


### PR DESCRIPTION
# This PR
Simply increases the `GenerateZKProof` timeout from 2 minutes to 3 minutes as it has timed out a few times already.