### PR TITLE
Fixes to MEDIUM severity issues from Jeb's report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ config/jwt.txt
 *.pem
 
 packages/contracts-bedrock/lib/automate/
+
+
+# Claude
+.claude

--- a/README_ESPRESSO.md
+++ b/README_ESPRESSO.md
@@ -52,22 +52,46 @@ Run the Espresso smoke tests:
 > just smoke-tests
 ```
 
-Run the Espresso integration tests. Note, this can take up to 30min.
+Run the Espresso integration tests. Tests run in parallel (default 4 concurrent). Tune with `just espresso-tests parallel=2` on constrained machines.
 
 ```console
 > just espresso-tests
 ```
 
+To skip contract recompilation when artifacts already exist:
+
+```console
+> just espresso-tests-no-compile
+```
+
+To run a single integration test by name:
+
+```console
+> just espresso-test TestBatcherSwitching
+```
+
+#### Integration test groups
+
+For faster iteration during development, you can run a subset of related tests:
+
+```console
+> just espresso-tests-caff        # Caff node tests
+> just espresso-tests-batcher     # Batcher auth, inbox, stateless, fallback
+> just espresso-tests-derivation  # Pipeline and soft confirmation tests
+> just espresso-tests-reorg       # Reorg and finality tests
+> just espresso-tests-liveness    # Liveness and degradation tests
+```
+
 To run all the standard OP stack (w/o Espresso integration) tests (slow):
 
 ```console
-> just tests
+> just op-tests
 ```
 
 To run a subset of the tests above (fast):
 
 ```console
-> just fast-tests
+> just fast-op-tests
 ```
 
 To run the devnet tests:
@@ -137,7 +161,9 @@ just gen-bindings
 
 If some containers are still running (due to failed tests) run this command to stop and delete all the Espresso containers:
 
-> just remove-containers
+```console
+> just remove-espresso-containers
+```
 
 ### Guide: Setting Up an Enclave-Enabled Nitro EC2 Instance
 
@@ -295,10 +321,10 @@ just
 cd ../
 ```
 
-* Build the contracts. This step needs to be re-run if the contracts are modified.
+* Build the contracts. This step needs to be re-run if the contracts are modified. Use `compile-contracts-fast` for faster builds (skips test contracts), or `compile-contracts` for a full build.
 
 ```console
-just compile-contracts
+just compile-contracts-fast
 ```
 
 * Go to the `espresso` directory.

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -23,7 +23,6 @@ const (
 	BatchPast
 )
 
-var ErrAtCapacity = errors.New("batch buffer at capacity")
 var ErrDuplicateBatch = errors.New("duplicate batch")
 
 type Batch interface {
@@ -34,19 +33,13 @@ type Batch interface {
 }
 
 type BatchBuffer[B Batch] struct {
-	batches  []B
-	capacity uint64
+	batches []B
 }
 
 func NewBatchBuffer[B Batch](capacity uint64) BatchBuffer[B] {
 	return BatchBuffer[B]{
-		batches:  []B{},
-		capacity: capacity,
+		batches: []B{},
 	}
-}
-
-func (b BatchBuffer[B]) Capacity() uint64 {
-	return b.capacity
 }
 
 func (b BatchBuffer[B]) Len() int {
@@ -57,11 +50,10 @@ func (b *BatchBuffer[B]) Clear() {
 	b.batches = nil
 }
 
+// Insert adds a batch to the buffer in sorted order by batch number.
+// The caller (processEspressoTransaction) is responsible for ensuring the buffer
+// stays bounded by dropping batches that are too far ahead of the current position.
 func (b *BatchBuffer[B]) Insert(batch B) error {
-	if uint64(b.Len()) >= b.capacity {
-		return ErrAtCapacity
-	}
-
 	pos, alreadyExists := slices.BinarySearchFunc(b.batches, batch, func(a, t B) int {
 		// Note: we use a custom comparison function that returns 0 only if the batches are actually
 		// the same to ensure that newer batches with the same number are stored later in the buffer

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -36,7 +36,7 @@ type BatchBuffer[B Batch] struct {
 	batches []B
 }
 
-func NewBatchBuffer[B Batch]() BatchBuffer[B] {
+func NewBatchBuffer[B Batch](capacity uint64) BatchBuffer[B] {
 	return BatchBuffer[B]{
 		batches: []B{},
 	}

--- a/espresso/batch_buffer.go
+++ b/espresso/batch_buffer.go
@@ -36,7 +36,7 @@ type BatchBuffer[B Batch] struct {
 	batches []B
 }
 
-func NewBatchBuffer[B Batch](capacity uint64) BatchBuffer[B] {
+func NewBatchBuffer[B Batch]() BatchBuffer[B] {
 	return BatchBuffer[B]{
 		batches: []B{},
 	}

--- a/espresso/batch_buffer_test.go
+++ b/espresso/batch_buffer_test.go
@@ -59,24 +59,21 @@ func newMockBatchWithHash(number uint64, hash common.Hash) mockBatch {
 	}
 }
 
-// TestBatchBufferInsertAtCapacity verifies that the buffer respects its capacity limit
-// and returns ErrAtCapacity when attempting to insert beyond capacity.
-func TestBatchBufferInsertAtCapacity(t *testing.T) {
-	const testCapacity uint64 = 3
-
-	// Create a buffer with small capacity
-	buffer := NewBatchBuffer[mockBatch](testCapacity)
-
-	// Verify Capacity() returns the configured capacity
-	require.Equal(t, testCapacity, buffer.Capacity())
+// TestBatchBufferInsertAndRetrieve verifies basic insert and retrieval behavior.
+// Note: the buffer no longer enforces a capacity limit internally. Bounding is
+// done by the streamer, which drops batches too far ahead of the current position
+// (see MaxBatchOutOfOrder). The buffer itself accepts any number of inserts.
+func TestBatchBufferInsertAndRetrieve(t *testing.T) {
+	buffer := NewBatchBuffer[mockBatch](0)
 
 	// Verify buffer starts empty
 	require.Equal(t, 0, buffer.Len())
 
-	// Insert batches up to capacity
+	// Insert batches
 	batch1 := newMockBatch(1)
 	batch2 := newMockBatch(2)
 	batch3 := newMockBatch(3)
+	batch4 := newMockBatch(4)
 
 	err := buffer.Insert(batch1)
 	require.NoError(t, err)
@@ -90,40 +87,29 @@ func TestBatchBufferInsertAtCapacity(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, buffer.Len())
 
-	// Verify inserting beyond capacity returns ErrAtCapacity
-	batch4 := newMockBatch(4)
+	// Inserting a fourth batch succeeds (no capacity limit)
 	err = buffer.Insert(batch4)
-	require.ErrorIs(t, err, ErrAtCapacity)
+	require.NoError(t, err)
+	require.Equal(t, 4, buffer.Len())
 
-	// Verify buffer contents unchanged after failed insert
-	require.Equal(t, 3, buffer.Len())
-	require.Equal(t, testCapacity, buffer.Capacity())
-
-	// Verify the original batches are still accessible and in sorted order
-	got := buffer.Get(0)
-	require.NotNil(t, got)
-	require.Equal(t, uint64(1), got.Number())
-
-	got = buffer.Get(1)
-	require.NotNil(t, got)
-	require.Equal(t, uint64(2), got.Number())
-
-	got = buffer.Get(2)
-	require.NotNil(t, got)
-	require.Equal(t, uint64(3), got.Number())
+	// Verify all batches are accessible and in sorted order
+	for i := 0; i < 4; i++ {
+		got := buffer.Get(i)
+		require.NotNil(t, got)
+		require.Equal(t, uint64(i+1), got.Number())
+	}
 
 	// Verify Get returns nil for out of bounds
-	require.Nil(t, buffer.Get(3))
+	require.Nil(t, buffer.Get(4))
 }
 
 // TestBatchBufferInsertDuplicateHandling verifies that:
 // - Inserting the exact same batch (same number AND same hash) does not create a duplicate
 // - Inserting a batch with the same number but different hash IS allowed
 func TestBatchBufferInsertDuplicateHandling(t *testing.T) {
-	const testCapacity uint64 = 10
 	const batchNumberN uint64 = 42
 
-	buffer := NewBatchBuffer[mockBatch](testCapacity)
+	buffer := NewBatchBuffer[mockBatch](0)
 
 	// Create first batch with number N and hash H1
 	hashH1 := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
@@ -257,9 +243,6 @@ func TestBatchBufferClear(t *testing.T) {
 	require.Nil(t, buffer.Peek())
 	require.Nil(t, buffer.Pop())
 	require.Nil(t, buffer.Get(0))
-
-	// Verify capacity is unchanged
-	require.Equal(t, uint64(10), buffer.Capacity())
 
 	// Verify we can insert again after clear
 	err = buffer.Insert(newMockBatch(1))

--- a/espresso/environment/10_soft_confirmation_integrity_test.go
+++ b/espresso/environment/10_soft_confirmation_integrity_test.go
@@ -484,6 +484,7 @@ func submitValidDataWithRandomSignature(
 // L1. All of these should yield the same blocks in the same order (but at
 // different times).
 func TestSequencerFeedConsistency(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -546,6 +547,7 @@ func TestSequencerFeedConsistency(t *testing.T) {
 // to Espresso. Such attacks should not cause Espresso to finalize something
 // different than the sequencer feed.
 func TestSequencerFeedConsistencyWithAttackOnEspresso(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/espresso/environment/11_forced_transaction_test.go
+++ b/espresso/environment/11_forced_transaction_test.go
@@ -121,23 +121,27 @@ func ForcedTransaction(t *testing.T, withSmallSequencerWindow bool, withEspresso
 // TestForcedTransactionWithoutEspressoSmallWindow verifies that the withdrawal transaction is
 // enforced after the sequencer window is passed when launching without the Espresso dev node.
 func TestForcedTransactionWithoutEspressoSmallWindow(t *testing.T) {
+	t.Parallel()
 	ForcedTransaction(t, true, false)
 }
 
 // TestForcedTransactionWithoutEspressoLargeWindow verifies that the withdrawal transaction is not
 // enforced before the sequencer window is passed when launching without the Espresso dev node.
 func TestForcedTransactionWithoutEspressoLargeWindow(t *testing.T) {
+	t.Parallel()
 	ForcedTransaction(t, false, false)
 }
 
 // TestForcedTransactionWithEspressoSmallWindow verifies that the withdrawal transaction is
 // enforced after the sequencer window is passed when launching with the Espresso dev node.
 func TestForcedTransactionWithEspressoSmallWindow(t *testing.T) {
+	t.Parallel()
 	ForcedTransaction(t, true, true)
 }
 
 // TestForcedTransactionWithEspressoLargeWindow verifies that the withdrawal transaction is not
 // enforced before the sequencer window is passed when launching with the Espresso dev node.
 func TestForcedTransactionWithEspressoLargeWindow(t *testing.T) {
+	t.Parallel()
 	ForcedTransaction(t, false, false)
 }

--- a/espresso/environment/14_batcher_fallback_test.go
+++ b/espresso/environment/14_batcher_fallback_test.go
@@ -68,6 +68,7 @@ func waitForRollupToMovePastL1Block(ctx context.Context, rollupCli *sources.Roll
 // derives the same chain state as the verifier by comparing block hashes at the
 // same height.
 func TestBatcherSwitching(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -422,6 +423,7 @@ func retryWaitNTimes(fn func() error, n int) error {
 // switched to the fallback and the fallback batcher should continue
 // submitting the remaining frames of the channel without any issues.
 func TestFallbackMechanismIntegrationTestChannelNotClosed(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeoutCause(context.Background(), time.Minute*10, fmt.Errorf("test did not complete within expected time allotment: %w", context.DeadlineExceeded))
 	defer cancel()
 

--- a/espresso/environment/1_espresso_benchmark_test.go
+++ b/espresso/environment/1_espresso_benchmark_test.go
@@ -45,6 +45,7 @@ import (
 // For the purposes of this test the "reasonable" value is defined to
 // be 2 seconds.
 func TestE2eDevnetWithEspressoFastConfirmationStability(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/espresso/environment/2_espresso_liveness_test.go
+++ b/espresso/environment/2_espresso_liveness_test.go
@@ -57,6 +57,7 @@ import (
 // submitter that the transaction was submitted successfully, and withholding
 // the submission itself.
 func TestE2eDevnetWithEspressoDegradedLiveness(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -165,6 +166,7 @@ func TestE2eDevnetWithEspressoDegradedLiveness(t *testing.T) {
 // we can use that Block information to track the arrival of the Transaction
 // / Block coming from Espresso.
 func TestE2eDevnetWithEspressoDegradedLivenessViaCaffNode(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/espresso/environment/3_1_espresso_caff_node_test.go
+++ b/espresso/environment/3_1_espresso_caff_node_test.go
@@ -32,6 +32,7 @@ import (
 // The actual tests is unable to make Alice's initial balance zero, and will
 // instead just check Alice's starting balance against the rest of the cases.
 func TestE2eDevnetWithEspressoWithCaffNodeDeterministicDerivation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/3_2_espresso_deterministic_state_test.go
+++ b/espresso/environment/3_2_espresso_deterministic_state_test.go
@@ -44,6 +44,7 @@ import (
 //		Once a state of op-node is finalized on L1, it should match the state that was earlier reported by the caff-node for the same block.
 
 func TestDeterministicDerivationExecutionStateWithInvalidTransaction(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/3_3_fast_derivation_and_caff_node_test.go
+++ b/espresso/environment/3_3_fast_derivation_and_caff_node_test.go
@@ -51,6 +51,7 @@ func checkNewBlocks(ctx context.Context, client *ethclient.Client, previousBlock
 //
 // checkNewBlocks checks for new blocks and verifies their timestamps
 func TestFastDerivationAndCaffNode(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 

--- a/espresso/environment/4_confirmation_integrity_with_reorgs_test.go
+++ b/espresso/environment/4_confirmation_integrity_with_reorgs_test.go
@@ -200,6 +200,7 @@ func run(ctx context.Context, t *testing.T, system *e2esys.System) {
 //	Assert:
 //		L == L'
 func TestConfirmationIntegrityWithReorgs(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/5_batch_authentication_test.go
+++ b/espresso/environment/5_batch_authentication_test.go
@@ -16,6 +16,7 @@ import (
 // when provided with an invalid attestation. This test ensures that the BatchAuthenticator
 // contract properly validates attestations.
 func TestE2eDevnetWithInvalidAttestation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -55,6 +56,7 @@ func TestE2eDevnetWithInvalidAttestation(t *testing.T) {
 // TestE2eDevnetWithUnattestedBatcherKey verifies that when a batcher key is not properly
 // attested, the L2 chain can still produce unsafe blocks but cannot progress to safe L2 blocks.
 func TestE2eDevnetWithUnattestedBatcherKey(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/6_batch_inbox_test.go
+++ b/espresso/environment/6_batch_inbox_test.go
@@ -36,6 +36,7 @@ import (
 //	Assert that the batch transaction lands on L1 (BatchInbox is an EOA).
 //	Assert that the derivation pipeline doesn't progress (no auth event).
 func TestE2eDevnetWithoutAuthenticatingBatches(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/7_stateless_batcher_test.go
+++ b/espresso/environment/7_stateless_batcher_test.go
@@ -36,6 +36,7 @@ import (
 //		Query the OP node to check that Alice balance has been increased by n-2
 
 func TestStatelessBatcher(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/8_reorg_test.go
+++ b/espresso/environment/8_reorg_test.go
@@ -33,6 +33,7 @@ import (
 //		The batcher doesn't submit a block without finalized L1 origin to the L1.
 //		After the L1 origin is finalized, the batcher submits the block.
 func TestBatcherWaitForFinality(t *testing.T) {
+	t.Parallel()
 	// Basic test setup.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
@@ -96,6 +97,7 @@ func TestBatcherWaitForFinality(t *testing.T) {
 //	Assert:
 //		The Caff node's safe L2 head always has a finalized L1 origin.
 func TestCaffNodeWaitForFinality(t *testing.T) {
+	t.Parallel()
 	// Basic test setup.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
@@ -234,6 +236,7 @@ func runL1Reorg(ctx context.Context, t *testing.T, system *e2esys.System) {
 //	Assert that derivation pipeline still progresses
 //	Assert that Caff and OP node report a new block at the target L2 height
 func TestE2eDevnetWithL1Reorg(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/environment/9_pipeline_enhancement_test.go
+++ b/espresso/environment/9_pipeline_enhancement_test.go
@@ -42,6 +42,7 @@ import (
 //		corresponding BatchInfoAuthenticated event.
 
 func TestPipelineEnhancement(t *testing.T) {
+	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/espresso/environment/espresso_dev_node_test.go
+++ b/espresso/environment/espresso_dev_node_test.go
@@ -14,6 +14,7 @@ import (
 // Docker implementation. It starts the dev node and then stops it. And tries
 // to ensure that the e2e system, and the docker container stop correctly.
 func TestEspressoDockerDevNodeSmokeTest(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -89,6 +90,7 @@ func TestEspressoDockerDevNodeSmokeTest(t *testing.T) {
 // TestE2eDevnetWithEspressoSimpleTransactions launches the e2e Dev Net with the Espresso Dev Node
 // and runs a couple of simple transactions to it.
 func TestE2eDevnetWithEspressoSimpleTransactions(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -112,6 +114,7 @@ func TestE2eDevnetWithEspressoSimpleTransactions(t *testing.T) {
 // TestE2eDevnetWithEspressoAndAltDaSimpleTransactions launches the e2e Dev Net with the Espresso
 // Dev Node in AltDA mode and runs a couple of simple transactions to it.
 func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -143,6 +146,7 @@ func TestE2eDevnetWithEspressoAndAltDaSimpleTransactions(t *testing.T) {
 // TestE2eDevnetWithoutEspressoSimpleTransactions launches the e2e Dev Net
 // without the Espresso Dev Node and runs a couple of simple transactions to it.
 func TestE2eDevnetWithoutEspressoSimpleTransaction(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -23,9 +23,7 @@ import (
 //
 // This eliminates the need for capacity-based overflow handling (skipPos / rewind).
 // The tradeoff is that if Espresso confirms batches more than MaxBatchOutOfOrder apart,
-// the batcher must resubmit them. This is an extremely unlikely scenario, and the batcher
-// is only trusted for liveness (not safety), so bugs there can only cause stalls, not
-// invalid state transitions.
+// the batcher must resubmit them. This is an extremely unlikely scenario, that would only yield a liveness failure.
 const MaxBatchOutOfOrder uint64 = 1024
 
 // Espresso light client bindings don't have an explicit name for this struct,

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -2,6 +2,7 @@ package espresso
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -422,7 +423,7 @@ func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, trans
 			"epochNum", header.Number,
 			"timestamp", header.Time)
 		err := s.BatchBuffer.Insert(*batch)
-		if err == ErrDuplicateBatch {
+		if errors.Is(err, ErrDuplicateBatch) {
 			s.Log.Warn("Dropping batch with duplicate hash")
 		}
 	}

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -140,9 +140,10 @@ func NewEspressoStreamer[B Batch](
 		EspressoLightClient: lightClient,
 		Log:                 log,
 		Namespace:           namespace,
-		// Internally, BatchPos is the position of the batch we are to give out next, hence the +1
+		// BatchPos is the next batch to give out.
+		// Reset() sets BatchPos = fallbackBatchPos + 1, so New and Reset stay consistent.
 		BatchPos:               originBatchPos + 1,
-		fallbackBatchPos:       originBatchPos + 1,
+		fallbackBatchPos:       originBatchPos,
 		BatchBuffer:            NewBatchBuffer[B](MaxBatchOutOfOrder),
 		HotShotPollingInterval: hotShotPollingInterval,
 		finalizedL1HashCache:   finalizedL1HashCache,

--- a/espresso/streamer.go
+++ b/espresso/streamer.go
@@ -2,9 +2,7 @@ package espresso
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"time"
 
@@ -18,7 +16,17 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-const BatchBufferCapacity uint64 = 1024
+// MaxBatchOutOfOrder defines how far ahead of the current BatchPos a batch can be
+// before it is considered invalid and dropped. This bounds the buffer size: since any
+// batch with number > BatchPos + MaxBatchOutOfOrder is dropped on arrival, the buffer
+// can never hold more than MaxBatchOutOfOrder entries.
+//
+// This eliminates the need for capacity-based overflow handling (skipPos / rewind).
+// The tradeoff is that if Espresso confirms batches more than MaxBatchOutOfOrder apart,
+// the batcher must resubmit them. This is an extremely unlikely scenario, and the batcher
+// is only trusted for liveness (not safety), so bugs there can only cause stalls, not
+// invalid state transitions.
+const MaxBatchOutOfOrder uint64 = 1024
 
 // Espresso light client bindings don't have an explicit name for this struct,
 // so we define it here to avoid spelling it out every time
@@ -95,15 +103,12 @@ type BatchStreamer[B Batch] struct {
 	originHotShotPos uint64
 	// Latest finalized block on the L1.
 	FinalizedL1 eth.L1BlockRef
-	// If the batch buffer is full, but we don't yet have the next batch,
-	// we will start skipping other batches until we encounter the missing batch.
-	// This position will be used to record such a situation occurring, when
-	// we find the target batch HotShot position will be reset to this.
-	skipPos   uint64
-	headBatch *B
+	headBatch   *B
 
 	// Maintained in sorted order, but may be missing batches if we receive
-	// any out of order.
+	// any out of order. The buffer size is provably bounded by MaxBatchOutOfOrder
+	// because processEspressoTransaction drops any batch whose number exceeds
+	// BatchPos + MaxBatchOutOfOrder.
 	BatchBuffer BatchBuffer[B]
 
 	// Cache for finalized L1 block hashes, keyed by block number.
@@ -140,14 +145,13 @@ func NewEspressoStreamer[B Batch](
 		// Internally, BatchPos is the position of the batch we are to give out next, hence the +1
 		BatchPos:               originBatchPos + 1,
 		fallbackBatchPos:       originBatchPos + 1,
-		BatchBuffer:            NewBatchBuffer[B](BatchBufferCapacity),
+		BatchBuffer:            NewBatchBuffer[B](MaxBatchOutOfOrder),
 		HotShotPollingInterval: hotShotPollingInterval,
 		finalizedL1HashCache:   finalizedL1HashCache,
 		unmarshalBatch:         unmarshalBatch,
 		originHotShotPos:       originHotShotPos,
 		fallbackHotShotPos:     originHotShotPos,
 		hotShotPos:             originHotShotPos,
-		skipPos:                math.MaxUint64,
 	}
 }
 
@@ -157,7 +161,6 @@ func (s *BatchStreamer[B]) Reset() {
 	s.hotShotPos = s.fallbackHotShotPos
 	s.BatchPos = s.fallbackBatchPos + 1
 	s.headBatch = nil
-	s.skipPos = math.MaxUint64
 	s.BatchBuffer.Clear()
 }
 
@@ -356,10 +359,7 @@ func (s *BatchStreamer[B]) fetchHotShotRange(ctx context.Context, start, finish 
 
 	for _, namespaceTransaction := range namespaceRangeTransactions {
 		for _, txn := range namespaceTransaction.Transactions {
-			err := s.processEspressoTransaction(ctx, txn.Payload)
-			if errors.Is(err, ErrAtCapacity) {
-				s.skipPos = min(s.skipPos, start)
-			}
+			s.processEspressoTransaction(ctx, txn.Payload)
 		}
 	}
 
@@ -368,12 +368,11 @@ func (s *BatchStreamer[B]) fetchHotShotRange(ctx context.Context, start, finish 
 
 // processEspressoTransaction is a helper method that encapsulates the logic of
 // processing batches from the transactions in a block fetched from Espresso.
-// It will return an error if the transaction contains a valid batch, but the buffer is full.
-func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, transaction espressoCommon.Bytes) error {
+func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, transaction espressoCommon.Bytes) {
 	batch, err := s.UnmarshalBatch(transaction)
 	if err != nil {
 		s.Log.Warn("Dropping batch with invalid transaction data", "error", err)
-		return nil
+		return
 	}
 
 	validity := s.CheckBatch(ctx, *batch)
@@ -381,16 +380,29 @@ func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, trans
 	switch validity {
 	case BatchDrop:
 		s.Log.Info("Dropping batch", batch)
-		return nil
+		return
 
 	case BatchPast:
 		s.Log.Info("Batch already processed. Skipping", "batch", (*batch).Number())
-		return nil
+		return
 
 	case BatchUndecided:
 		s.Log.Warn("Inserting undecided batch", "batch", (*batch).Hash())
 
 	case BatchAccept:
+	}
+
+	// Drop batches that are too far ahead of where we are. This bounds the buffer size
+	// to at most MaxBatchOutOfOrder entries, eliminating the need for capacity-based
+	// overflow handling. If a batch is confirmed by Espresso this far out of order,
+	// the batcher is responsible for resubmitting it — this is an extremely unlikely
+	// scenario and only affects liveness, not safety.
+	if (*batch).Number() > s.BatchPos+MaxBatchOutOfOrder {
+		s.Log.Warn("Dropping batch too far ahead of current position",
+			"batchNumber", (*batch).Number(),
+			"batchPos", s.BatchPos,
+			"maxOutOfOrder", MaxBatchOutOfOrder)
+		return
 	}
 
 	header := (*batch).Header()
@@ -405,39 +417,25 @@ func (s *BatchStreamer[B]) processEspressoTransaction(ctx context.Context, trans
 			"timestamp", header.Time)
 		s.headBatch = batch
 	} else {
-		// Otherwise, try to buffer it. If the buffer is full, forward the error up to record
-		// that we're skipping batches and will need to revisit when the buffer drains
 		s.Log.Info("Inserting batch into buffer",
 			"hash", (*batch).Hash(),
 			"parentHash", header.ParentHash,
 			"epochNum", header.Number,
 			"timestamp", header.Time)
 		err := s.BatchBuffer.Insert(*batch)
-		if errors.Is(err, ErrDuplicateBatch) {
+		if err == ErrDuplicateBatch {
 			s.Log.Warn("Dropping batch with duplicate hash")
 		}
-		if errors.Is(err, ErrAtCapacity) {
-			return err
-		}
 	}
-
-	return nil
 }
 
 // UnmarshalBatch implements EspressoStreamerIFace
 func (s *BatchStreamer[B]) Next(ctx context.Context) *B {
 	// Is the next batch available?
 	if s.HasNext(ctx) {
-		// Current batch is going to be processed, update fallback batch position
 		s.BatchPos += 1
 		head := s.headBatch
 		s.headBatch = nil
-		// If we have been skipping batches, now is the time
-		// to rewind and start considering batches again: we've made more space
-		if s.skipPos != math.MaxUint64 {
-			s.hotShotPos = s.skipPos
-			s.skipPos = math.MaxUint64
-		}
 		return head
 	}
 

--- a/espresso/streamer_test.go
+++ b/espresso/streamer_test.go
@@ -1005,29 +1005,19 @@ func TestStreamerMultipleBatchesSameNumber(t *testing.T) {
 	})
 }
 
-// TestStreamerBufferCapacityAndSkipPos tests the skip position mechanism when the buffer fills up.
-func TestStreamerBufferCapacityAndSkipPos(t *testing.T) {
+// TestStreamerMaxBatchOutOfOrder tests that batches too far ahead of the current
+// BatchPos are dropped, bounding the buffer size without needing capacity-based
+// overflow or skip/rewind logic.
+func TestStreamerMaxBatchOutOfOrder(t *testing.T) {
 	namespace := uint64(42)
 	chainID := big.NewInt(int64(namespace))
 	privateKeyString := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 	chainSignerFactory, signerAddress, _ := crypto.ChainSignerFactoryFromConfig(&NoOpLogger{}, privateKeyString, "", "", opsigner.CLIConfig{})
 	chainSigner := chainSignerFactory(chainID, common.Address{})
 
-	t.Run("skipPos not overwritten across multiple fetch ranges", func(t *testing.T) {
-		// Regression test: when the Update loop iterates through multiple
-		// HotShot block ranges, hitting ErrAtCapacity in a later range must
-		// NOT overwrite skipPos set by an earlier range. Otherwise the rewind
-		// skips the earlier range's batches permanently.
-		//
-		// Scenario:
-		//   - Enough batches (starting from 2, skipping 1) are placed to fill
-		//     the buffer, plus an extra fetch range worth of batches beyond it.
-		//   - The extra batches are dropped because the buffer is full.
-		//     skipPos should record the earliest range where capacity was hit.
-		//   - Batch 1 is injected later, consumed, and triggers a rewind.
-		//   - After draining the buffer, the next batch must come from the
-		//     re-fetched overflow. If skipPos was overwritten to a later range
-		//     start, the rewind won't go far enough and those batches are lost.
+	t.Run("batches beyond MaxBatchOutOfOrder are dropped", func(t *testing.T) {
+		// Verify that a batch whose number exceeds BatchPos + MaxBatchOutOfOrder
+		// is silently dropped and never appears in the buffer or as the head batch.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -1053,64 +1043,37 @@ func TestStreamerBufferCapacityAndSkipPos(t *testing.T) {
 		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
 		require.NoError(t, err)
 
-		// Place enough batches to fill the buffer and overflow by one full
-		// fetch range. Batch 1 is intentionally missing so HasNext stays
-		// false, forcing the Update loop to keep iterating across ranges.
-		totalBatches := int(espresso.BatchBufferCapacity) + int(espresso.HOTSHOT_BLOCK_FETCH_LIMIT)
-		for i := 0; i < totalBatches; i++ {
-			_, _, _, espTxn := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, uint64(i+2), chainSigner)
-			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
-		}
+		// Insert a batch that is exactly at the boundary (BatchPos + MaxBatchOutOfOrder).
+		// BatchPos is 1, so this batch number should be accepted.
+		boundaryBatchNum := uint64(1) + espresso.MaxBatchOutOfOrder
+		_, _, _, espTxnBoundary := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, boundaryBatchNum, chainSigner)
+		state.AddEspressoTransactionData(0, namespace, espTxnBoundary)
 
-		// Update processes all ranges. The buffer fills up partway through,
-		// and all subsequent batches are dropped with ErrAtCapacity.
+		// Insert a batch that is one beyond the boundary — should be dropped.
+		tooFarBatchNum := boundaryBatchNum + 1
+		_, _, _, espTxnTooFar := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, tooFarBatchNum, chainSigner)
+		state.AddEspressoTransactionData(1, namespace, espTxnTooFar)
+
 		err = streamer.Update(ctx)
 		require.NoError(t, err)
+
+		// The boundary batch should be buffered, but we can't consume it yet
+		// (batch 1 is missing). The too-far batch should have been dropped entirely.
 		require.False(t, streamer.HasNext(ctx))
 
-		// Inject batch 1 beyond all existing data.
-		batch1Pos := uint64(totalBatches + 10)
-		_, _, _, espTxn1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
-		state.AddEspressoTransactionData(batch1Pos, namespace, espTxn1)
-
-		// Fetch and consume batch 1 — triggers the rewind via skipPos.
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-		require.True(t, streamer.HasNext(ctx))
-		batch := streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(1), batch.Number())
-
-		// Drain the entire buffer of previously-buffered batches.
-		firstOverflow := uint64(espresso.BatchBufferCapacity) + 2
-		for expectedNum := uint64(2); expectedNum < firstOverflow; expectedNum++ {
-			err = streamer.Update(ctx)
-			require.NoError(t, err)
-			require.True(t, streamer.HasNext(ctx), "expected batch %d to be available", expectedNum)
-			batch = streamer.Next(ctx)
-			require.NotNil(t, batch)
-			require.Equal(t, expectedNum, batch.Number())
-		}
-
-		// The first batch that was dropped due to capacity must now be
-		// recoverable via the rewind. If skipPos was overwritten to a later
-		// range, this batch is permanently lost.
-		err = streamer.Update(ctx)
-		require.NoError(t, err)
-		require.True(t, streamer.HasNext(ctx), "first overflow batch must be available after rewind — skipPos must preserve the earliest range")
-		batch = streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, firstOverflow, batch.Number(), "first batch after buffer drain must not be skipped")
+		// The buffer should contain exactly 1 batch (the boundary one).
+		require.Equal(t, 1, streamer.BatchBuffer.Len())
 	})
 
-	t.Run("new batch for current BatchPos arrives when buffer full", func(t *testing.T) {
+	t.Run("batches within range are buffered and consumable", func(t *testing.T) {
+		// Verify that out-of-order batches within MaxBatchOutOfOrder are buffered
+		// and become consumable once the missing batch arrives.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		state := NewMockStreamerSource()
 		logger := new(NoOpLogger)
 
-		// Create streamer - after Refresh with SafeL2.Number=0, BatchPos becomes 1
 		streamer := espresso.NewEspressoStreamer(
 			namespace,
 			state,
@@ -1126,38 +1089,34 @@ func TestStreamerBufferCapacityAndSkipPos(t *testing.T) {
 
 		rng := rand.New(rand.NewSource(7))
 
-		// Refresh state - after this, BatchPos becomes 1
 		syncStatus := state.SyncStatus()
 		err := streamer.Refresh(ctx, syncStatus.FinalizedL1, syncStatus.SafeL2.Number, syncStatus.SafeL2.L1Origin)
 		require.NoError(t, err)
 
-		// Fill buffer with future batches (2, 3, 4, ...)
-		for i := 0; i < int(espresso.BatchBufferCapacity); i++ {
-			_, _, _, espTxn := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, uint64(i+2), chainSigner)
-			state.AddEspressoTransactionData(uint64(i), namespace, espTxn)
-		}
+		// Insert batches 2 and 3, skipping batch 1.
+		_, _, _, espTxn2 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 2, chainSigner)
+		state.AddEspressoTransactionData(0, namespace, espTxn2)
+		_, _, _, espTxn3 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 3, chainSigner)
+		state.AddEspressoTransactionData(1, namespace, espTxn3)
 
-		// Update to fill buffer
 		err = streamer.Update(ctx)
 		require.NoError(t, err)
+		require.False(t, streamer.HasNext(ctx), "batch 1 is missing, should not have next")
 
-		// HasNext should be false (batch 1 is missing)
-		require.False(t, streamer.HasNext(ctx))
-
-		// Now add batch 1 (the one we need)
-		laterPos := uint64(espresso.BatchBufferCapacity + 1)
+		// Now add batch 1.
 		_, _, _, espTxn1 := state.CreateEspressoTxnData(ctx, namespace, rng, chainID, 1, chainSigner)
-		state.AddEspressoTransactionData(laterPos, namespace, espTxn1)
+		state.AddEspressoTransactionData(2, namespace, espTxn1)
 
-		// Update to get batch 1
 		err = streamer.Update(ctx)
 		require.NoError(t, err)
 
-		// Batch 1 should be assigned to headBatch directly (not buffered)
-		require.True(t, streamer.HasNext(ctx))
-		batch := streamer.Next(ctx)
-		require.NotNil(t, batch)
-		require.Equal(t, uint64(1), batch.Number())
+		// Consume all three batches in order.
+		for expectedNum := uint64(1); expectedNum <= 3; expectedNum++ {
+			require.True(t, streamer.HasNext(ctx), "expected batch %d to be available", expectedNum)
+			batch := streamer.Next(ctx)
+			require.NotNil(t, batch)
+			require.Equal(t, expectedNum, batch.Number())
+		}
 	})
 }
 

--- a/justfile
+++ b/justfile
@@ -17,6 +17,12 @@ op-tests:
 fast-op-tests:
  ./run_fast_tests.sh
 
+## Unit tests (no Docker, fast)
+# Espresso core (streamer, batch buffer), derivation pipeline, and batcher unit tests.
+espresso-unit-tests:
+  go test -count=1 -v ./espresso/ ./op-batcher/...
+  go test -count=1 -v -run TestEspresso ./op-node/rollup/derive/
+
 ## Integration tests
 
 espresso_tests_timeout := "35m"

--- a/justfile
+++ b/justfile
@@ -18,10 +18,10 @@ fast-op-tests:
  ./run_fast_tests.sh
 
 ## Unit tests (no Docker, fast)
-# Espresso core (streamer, batch buffer), derivation pipeline, and batcher unit tests.
-espresso-unit-tests:
-  go test -count=1 -v ./espresso/ ./op-batcher/...
-  go test -count=1 -v -run TestEspresso ./op-node/rollup/derive/
+# Espresso core (streamer, batch buffer)
+espresso-streamer-unit-tests:
+  go test -count=1 -v ./espresso/
+
 
 ## Integration tests
 

--- a/justfile
+++ b/justfile
@@ -9,12 +9,65 @@ build-rust-release:
   cd rollup-boost && cargo build --release -p rollup-boost --bin rollup-boost
 
 # Run the tests
-tests:
+
+## OP stack tests
+op-tests:
   ./run_all_tests.sh
 
-fast-tests:
+fast-op-tests:
  ./run_fast_tests.sh
 
+## Integration tests
+
+espresso_tests_timeout := "35m"
+# Max parallel tests. Each test spins up L1+L2+Espresso Docker containers.
+# 4 is a good default for 32GB RAM; reduce to 2 on constrained machines.
+espresso_tests_parallel := "4"
+
+espresso-tests timeout=espresso_tests_timeout parallel=espresso_tests_parallel: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -parallel={{parallel}} -v ./espresso/environment
+
+# Run espresso-tests without recompiling contracts (when artifacts already exist).
+espresso-tests-no-compile timeout=espresso_tests_timeout parallel=espresso_tests_parallel:
+ go test -timeout={{timeout}} -count=1 -parallel={{parallel}} -v ./espresso/environment
+
+# Run a single espresso integration test by name regex.
+espresso-test name timeout=espresso_tests_timeout: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -run '{{name}}' -v ./espresso/environment
+
+# Run a single espresso integration test without recompiling contracts.
+espresso-test-no-compile name timeout=espresso_tests_timeout:
+ go test -timeout={{timeout}} -count=1 -run '{{name}}' -v ./espresso/environment
+
+## Integration test groups (for targeted development)
+# Caff node tests
+espresso-tests-caff timeout=espresso_tests_timeout: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -parallel=3 -run 'TestE2eDevnetWithEspressoWithCaffNodeDeterministicDerivation|TestDeterministicDerivationExecutionState|TestFastDerivationAndCaffNode' -v ./espresso/environment
+
+# Batcher tests (auth, inbox, stateless, fallback)
+espresso-tests-batcher timeout=espresso_tests_timeout: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -parallel=4 -run 'TestE2eDevnetWithInvalidAttestation|TestE2eDevnetWithUnattestedBatcherKey|TestE2eDevnetWithoutAuthenticatingBatches|TestStatelessBatcher|TestBatcherSwitching|TestFallbackMechanism' -v ./espresso/environment
+
+# Derivation pipeline and soft confirmation tests
+espresso-tests-derivation timeout=espresso_tests_timeout: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -parallel=3 -run 'TestPipelineEnhancement|TestSequencerFeedConsistency|TestSoftConfirmation' -v ./espresso/environment
+
+# Reorg and finality tests
+espresso-tests-reorg timeout=espresso_tests_timeout: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -parallel=4 -run 'TestBatcherWaitForFinality|TestCaffNodeWaitForFinality|TestE2eDevnetWithL1Reorg|TestConfirmationIntegrityWithReorgs' -v ./espresso/environment
+
+# Liveness and degradation tests
+espresso-tests-liveness timeout=espresso_tests_timeout: compile-contracts-fast
+ go test -timeout={{timeout}} -count=1 -parallel=2 -run 'TestE2eDevnetWithEspressoDegradedLiveness' -v ./espresso/environment
+
+espresso-enclave-tests:
+  ESPRESSO_RUN_ENCLAVE_TESTS=true go test -timeout={{espresso_tests_timeout}} -count=1 ./espresso/enclave-tests/...
+
+smoke-tests: compile-contracts-fast
+ go test -run ^TestEspressoDockerDevNodeSmokeTest$ ./espresso/environment -v
+
+
+## Devnet tests
 devnet-tests: build-devnet
   U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -v ./espresso/devnet-tests/...
 
@@ -38,10 +91,11 @@ devnet-batcher-switching-test: build-devnet
 devnet-batcher-active-publish-only-test: build-devnet
   U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -v -run TestBatcherActivePublishOnly ./espresso/devnet-tests/...
 
-build-devnet: stop-containers compile-contracts
+build-devnet: stop-containers compile-contracts-fast
   rm -Rf espresso/deployment
   (cd op-deployer && just)
   (cd espresso && ./scripts/prepare-allocs.sh && docker compose build)
+
 
 golint:
  golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
@@ -56,30 +110,23 @@ run-l1-espresso-contracts-tests: compile-contracts
 compile-contracts-fast:
  (cd packages/contracts-bedrock && forge build --offline --skip "/**/test/**" && just fix-proxy-artifact)
 
+# Build the batcher enclave image for devnet tests.
 build-batcher-enclave-image:
  (cd kurtosis-devnet && just op-batcher-enclave-image)
-
-espresso_tests_timeout := "35m"
-espresso-tests timeout=espresso_tests_timeout: compile-contracts
- go test -timeout={{timeout}} -p=1 -count=1 ./espresso/environment
-
-espresso-enclave-tests:
-  ESPRESSO_RUN_ENCLAVE_TESTS=true go test -timeout={{espresso_tests_timeout}} -p=1 -count=1 ./espresso/enclave-tests/...
 
 
 IMAGE_NAME := "ghcr.io/espressosystems/espresso-sequencer/espresso-dev-node:release-20251120-lip2p-tcp-3855"
 remove-espresso-containers:
   docker remove --force $(docker ps -q --filter ancestor={{IMAGE_NAME}})
 
+
+# Contracts
 forge_artifacts_dir:="packages/contracts-bedrock/forge-artifacts"
 bindings_dir:="op-batcher/bindings"
 gen_bindings_cmd:="./espresso/scripts/gen_bindings.sh"
 gen-bindings:
   {{gen_bindings_cmd}} {{forge_artifacts_dir}}/BatchAuthenticator.sol/BatchAuthenticator.json > ./{{bindings_dir}}/batch_authenticator.go
   {{gen_bindings_cmd}} {{forge_artifacts_dir}}/OPSuccinctFaultDisputeGame.sol/OPSuccinctFaultDisputeGame.json > ./{{bindings_dir}}/opsuccinct_fault_dispute_game.go
-
-smoke-tests: compile-contracts
- go test -run ^TestEspressoDockerDevNodeSmokeTest$ ./espresso/environment -v
 
 # Clean up everything before running the tests
 nuke:


### PR DESCRIPTION
Closes tickets related to the MEDIUM severity issues from Jeb's [report](https://www.notion.so/espressosys/OP-Review-3092431b68e98080853ff0f8a78e2bed)
* [Reconsider need for skipping batches](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213432243074587?focus=true)
* [Potential inconsistency in New/Reset](https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213432243074595?focus=true)

### This PR:

- **Remove capacity-based overflow handling from batch buffer**: replaced the `skipPos`/rewind mechanism with a simpler approach — batches whose number exceeds `BatchPos + MaxBatchOutOfOrder` are dropped on arrival in `processEspressoTransaction`. This bounds the buffer to at most `MaxBatchOutOfOrder` entries without needing the `ErrAtCapacity` / `skipPos` / rewind machinery.
- **Fix `fallbackBatchPos` initialization bug**: `NewEspressoStreamer` previously set `fallbackBatchPos = originBatchPos + 1`, but `Reset()` computes `BatchPos = fallbackBatchPos + 1`. This meant a `New` followed by `Reset` would set `BatchPos` to `originBatchPos + 2`, skipping one batch. Fixed by setting `fallbackBatchPos = originBatchPos` so `New` and `Reset` produce the same `BatchPos`
- **Add `t.Parallel()` to integration tests**: all Espresso integration tests now declare `t.Parallel()`
- **Add `espresso-streamer-unit-tests` justfile target** for fast iteration on streamer/buffer unit tests

### This PR does not:

Address other fixes suggestions from Jeb's [report](https://www.notion.so/espressosys/OP-Review-3092431b68e98080853ff0f8a78e2bed). Another PR will be created for the low severity issues.

### Key places to review:

Changes to the streamer

### How to test this PR:  

* streamer unit tests pass (`just espresso-streamer-unit-tests`)
* Check CI is green

