### PR TITLE
`singular batch from op-node is` log without the transaction info

### DIFF
--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -208,7 +208,6 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 				aq.log.Warn("failed to unmarshal transaction", "index", i, "err", err)
 			}
 		}
-		}
 		aq.batch.LogContext(aq.log).Info("singular batch from op-node", "tx_hashes", txHashes, "concluding", concluding)
 	}
 

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -196,7 +196,7 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 		}
 		aq.batch = batch
 		aq.concluding = concluding
-		aq.log.Info("singular batch from op-node is ", "batch", aq.batch, "concluding", concluding)
+		aq.batch.LogContext(aq.log).Info("singular batch from op-node", "concluding", concluding)
 	}
 
 	// Actually generate the next attributes

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -200,11 +200,14 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 		// Log tx hashes instead of raw bytes, since hashes are compact whereas raw tx bytes can
 		// be large and truncated by DataDog.
 		txHashes := make([]common.Hash, 0, len(aq.batch.Transactions))
-		for _, rawTx := range aq.batch.Transactions {
+		for i, rawTx := range aq.batch.Transactions {
 			var tx types.Transaction
 			if err := tx.UnmarshalBinary(rawTx); err == nil {
 				txHashes = append(txHashes, tx.Hash())
+			} else {
+				aq.log.Warn("failed to unmarshal transaction", "index", i, "err", err)
 			}
+		}
 		}
 		aq.batch.LogContext(aq.log).Info("singular batch from op-node", "tx_hashes", txHashes, "concluding", concluding)
 	}

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -197,16 +197,14 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 		}
 		aq.batch = batch
 		aq.concluding = concluding
-		// Log tx hashes instead of raw bytes, since hashes are compact whereas raw tx bytes can
-		// be large and truncated by DataDog.
+		// Log compact tx hashes instead of raw bytes to avoid being truncated by DataDog.
 		txHashes := make([]common.Hash, 0, len(aq.batch.Transactions))
-		for i, rawTx := range aq.batch.Transactions {
+		for _, rawTx := range aq.batch.Transactions {
 			var tx types.Transaction
 			if err := tx.UnmarshalBinary(rawTx); err == nil {
 				txHashes = append(txHashes, tx.Hash())
-			} else {
-				aq.log.Warn("failed to unmarshal transaction", "index", i, "err", err)
 			}
+			// Malformed txs are skipped here and will be rejected during payload construction.
 		}
 		aq.batch.LogContext(aq.log).Info("singular batch from op-node", "tx_hashes", txHashes, "concluding", concluding)
 	}

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/espresso"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -196,7 +197,16 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 		}
 		aq.batch = batch
 		aq.concluding = concluding
-		aq.batch.LogContext(aq.log).Info("singular batch from op-node", "concluding", concluding)
+		// Log tx hashes instead of raw bytes, since hashes are compact whereas raw tx bytes can
+		// be large and truncated by DataDog.
+		txHashes := make([]common.Hash, 0, len(aq.batch.Transactions))
+		for _, rawTx := range aq.batch.Transactions {
+			var tx types.Transaction
+			if err := tx.UnmarshalBinary(rawTx); err == nil {
+				txHashes = append(txHashes, tx.Hash())
+			}
+		}
+		aq.batch.LogContext(aq.log).Info("singular batch from op-node", "tx_hashes", txHashes, "concluding", concluding)
 	}
 
 	// Actually generate the next attributes


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1212148617379345?focus=true.

### This PR:
* Adds transaction hashes to the batcher log.
* Simplifies the log call.

### This PR does not:
* Change other logged fields.