### PR TITLE
TEE devnet tests on ephemeral EC2 runners

### DIFF
--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -1,0 +1,147 @@
+name: EC2 Devnet Test (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tests:
+        description: "Go test -run regex pattern"
+        required: true
+        type: string
+      group-name:
+        description: "Human-readable name for this test group"
+        required: true
+        type: string
+    secrets:
+      GH_PERSONAL_ACCESS_TOKEN:
+        required: true
+      AWS_EC2_SUBNET_ID:
+        required: true
+      AWS_EC2_SECURITY_GROUP_ID:
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  start-runner:
+    name: Start EC2 runner (${{ inputs.group-name }})
+    runs-on: ubuntu-latest
+    environment: tee-testing
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::324783324287:role/github-optimism-espresso-integration-access
+          role-duration-seconds: 10800
+          aws-region: us-east-2
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: EspressoSystems/ec2-github-runner@v2-enclave
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ami-0d259f3ae020af5f9
+          ec2-instance-type: m6a.2xlarge
+          subnet-id: ${{ secrets.AWS_EC2_SUBNET_ID }}
+          security-group-id: ${{ secrets.AWS_EC2_SECURITY_GROUP_ID }}
+          enclave-options: true
+          ec2-volume-size: 100
+          ec2-volume-type: gp3
+          run-runner-as-user: ec2-user
+          startup-timeout-minutes: 10
+          pre-runner-script: |
+            # Ensure Docker is running
+            sudo systemctl enable --now docker
+            sudo usermod -aG docker ec2-user
+            sudo chown ec2-user /var/run/docker.sock
+
+            # Configure Nitro Enclaves allocator (4 GiB, 2 vCPUs)
+            sudo systemctl stop nitro-enclaves-allocator.service || true
+            echo -e '---\nmemory_mib: 4096\ncpu_count: 2' | sudo tee /etc/nitro_enclaves/allocator.yaml
+            sudo systemctl start nitro-enclaves-allocator.service
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "tee-devnet-${{ inputs.group-name }}"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"}
+            ]
+
+  run-tests:
+    name: Run tests (${{ inputs.group-name }})
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    timeout-minutes: 40
+    env:
+      ESPRESSO_RUN_ENCLAVE_TESTS: "true"
+      ESPRESSO_DEVNET_TESTS_LIVENESS_PERIOD: "1m"
+      ESPRESSO_DEVNET_TESTS_OUTAGE_PERIOD: "1m"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache submodules
+        uses: ./.github/actions/cache-submodules
+
+      # Nix is pre-installed on the AMI; configure it for this session.
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Set up Nix environment
+        uses: nicknovitski/nix-develop@v1
+
+      - name: Cache Go modules
+        uses: actions/setup-go@v5
+
+      - name: Download forge-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: forge-artifacts
+          path: packages/contracts-bedrock/forge-artifacts/
+
+      - name: Download deployment artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: devnet-deployment
+          path: espresso/deployment/
+
+      - name: Build Docker images (TEE profile)
+        run: |
+          cd espresso
+          COMPOSE_PROFILES=tee docker compose build
+          COMPOSE_PROFILES=tee docker compose pull --ignore-buildable
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Run tests (${{ inputs.group-name }})
+        run: gotestsum --format github-actions -- -timeout 35m -p 1 -count 1 -run '${{ inputs.tests }}' ./espresso/devnet-tests/...
+
+  stop-runner:
+    name: Stop EC2 runner (${{ inputs.group-name }})
+    needs:
+      - start-runner
+      - run-tests
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::324783324287:role/github-optimism-espresso-integration-access
+          role-duration-seconds: 10800
+          aws-region: us-east-2
+
+      - name: Stop EC2 runner
+        uses: EspressoSystems/ec2-github-runner@v2-enclave
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -118,7 +118,7 @@ jobs:
         run: |
           cd espresso
           COMPOSE_PROFILES=tee docker compose build
-          COMPOSE_PROFILES=tee docker compose pull --ignore-buildable --ignore-pull-failures
+          COMPOSE_PROFILES=tee docker compose pull --ignore-buildable
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -11,13 +11,10 @@ on:
         description: "Human-readable name for this test group"
         required: true
         type: string
-    secrets:
-      GH_PERSONAL_ACCESS_TOKEN:
-        required: true
-      AWS_EC2_SUBNET_ID:
-        required: true
-      AWS_EC2_SECURITY_GROUP_ID:
-        required: true
+    # Secrets (GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID)
+    # are sourced from the tee-testing environment, not passed as workflow inputs.
+    # This keeps the PAT off the EC2 self-hosted runner (only start-runner and
+    # stop-runner jobs reference the environment).
 
 permissions:
   id-token: write
@@ -132,6 +129,7 @@ jobs:
       - start-runner
       - run-tests
     runs-on: ubuntu-latest
+    environment: tee-testing
     if: ${{ always() }}
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -103,9 +103,6 @@ jobs:
           nix develop --command bash -c 'echo "$PATH"' | tr ':' '\n' >> "$GITHUB_PATH"
           nix develop --command bash -c 'env' | grep -v '^PATH=' >> "$GITHUB_ENV" || true
 
-      - name: Cache Go modules
-        uses: actions/setup-go@v5
-
       - name: Download forge-artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -133,6 +133,7 @@ jobs:
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           export NIX_CONFIG="extra-experimental-features = nix-command flakes"
           nix develop --command bash -c '
+            export PATH="$(go env GOPATH)/bin:$PATH"
             go install gotest.tools/gotestsum@latest
             gotestsum --format github-actions -- -timeout 35m -p 1 -count 1 -run '"'"'${{ inputs.tests }}'"'"' ./espresso/devnet-tests/...
           '

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -59,17 +59,6 @@ jobs:
             # Install libicu — required by the GitHub Actions runner (.NET Core dependency)
             sudo dnf install -y libicu
 
-            # Install docker compose plugin (not available in AL2023 repos)
-            sudo mkdir -p /usr/libexec/docker/cli-plugins
-            sudo curl -SL "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64" \
-              -o /usr/libexec/docker/cli-plugins/docker-compose
-            sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
-
-            # Ensure Docker is running
-            sudo systemctl enable --now docker
-            sudo usermod -aG docker ec2-user
-            sudo chown ec2-user /var/run/docker.sock
-
             # Configure Nitro Enclaves allocator (4 GiB, 2 vCPUs)
             sudo systemctl stop nitro-enclaves-allocator.service || true
             echo -e '---\nmemory_mib: 4096\ncpu_count: 2' | sudo tee /etc/nitro_enclaves/allocator.yaml
@@ -96,18 +85,29 @@ jobs:
       - name: Cache submodules
         uses: ./.github/actions/cache-submodules
 
-      # Nix is pre-installed on the AMI for ec2-user; add it to PATH
-      # and source the dev shell instead of using nix-quick-install-action
-      # (which fails because /nix already exists and isn't writable by the action).
-      - name: Set up Nix environment
+      - name: Set up Docker
         run: |
-          echo "/nix/var/nix/profiles/default/bin" >> $GITHUB_PATH
-          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-      - name: Enter Nix dev shell
+          # Ensure Docker is running and accessible
+          sudo systemctl enable --now docker
+          sudo usermod -aG docker ec2-user
+          sudo chown ec2-user /var/run/docker.sock
+
+          # Install docker compose plugin (not available in AL2023 repos)
+          sudo mkdir -p /usr/libexec/docker/cli-plugins
+          sudo curl -SL "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64" \
+            -o /usr/libexec/docker/cli-plugins/docker-compose
+          sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+
+          docker compose version
+
+      # Nix is pre-installed on the AMI for ec2-user. We use
+      # `nix develop --command` to run commands inside the dev shell
+      # rather than trying to export the environment into GITHUB_PATH/ENV,
+      # which is fragile on self-hosted runners.
+      - name: Warm up Nix dev shell
         run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
-          nix develop --command bash -c 'echo "$PATH"' | tr ':' '\n' >> "$GITHUB_PATH"
-          nix develop --command bash -c 'env' | grep -v '^PATH=' >> "$GITHUB_ENV" || true
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          nix develop --command echo "Nix dev shell ready"
 
       - name: Download forge-artifacts
         uses: actions/download-artifact@v4
@@ -127,11 +127,13 @@ jobs:
           COMPOSE_PROFILES=tee docker compose build
           COMPOSE_PROFILES=tee docker compose pull --ignore-buildable
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
-
       - name: Run tests (${{ inputs.group-name }})
-        run: gotestsum --format github-actions -- -timeout 35m -p 1 -count 1 -run '${{ inputs.tests }}' ./espresso/devnet-tests/...
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          nix develop --command bash -c '
+            go install gotest.tools/gotestsum@latest
+            gotestsum --format github-actions -- -timeout 35m -p 1 -count 1 -run '"'"'${{ inputs.tests }}'"'"' ./espresso/devnet-tests/...
+          '
 
   stop-runner:
     name: Stop EC2 runner (${{ inputs.group-name }})

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -57,7 +57,13 @@ jobs:
             sudo shutdown -h +50
 
             # Install libicu — required by the GitHub Actions runner (.NET Core dependency)
-            sudo dnf install -y libicu docker-compose-plugin
+            sudo dnf install -y libicu
+
+            # Install docker compose plugin (not available in AL2023 repos)
+            sudo mkdir -p /usr/libexec/docker/cli-plugins
+            sudo curl -SL "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64" \
+              -o /usr/libexec/docker/cli-plugins/docker-compose
+            sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 
             # Ensure Docker is running
             sudo systemctl enable --now docker

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -90,15 +90,18 @@ jobs:
       - name: Cache submodules
         uses: ./.github/actions/cache-submodules
 
-      # Nix is pre-installed on the AMI; configure it for this session.
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
+      # Nix is pre-installed on the AMI for ec2-user; add it to PATH
+      # and source the dev shell instead of using nix-quick-install-action
+      # (which fails because /nix already exists and isn't writable by the action).
       - name: Set up Nix environment
-        uses: nicknovitski/nix-develop@v1
+        run: |
+          echo "/nix/var/nix/profiles/default/bin" >> $GITHUB_PATH
+          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+      - name: Enter Nix dev shell
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || true
+          nix develop --command bash -c 'echo "$PATH"' | tr ':' '\n' >> "$GITHUB_PATH"
+          nix develop --command bash -c 'env' | grep -v '^PATH=' >> "$GITHUB_ENV" || true
 
       - name: Cache Go modules
         uses: actions/setup-go@v5

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -107,6 +107,7 @@ jobs:
       - name: Warm up Nix dev shell
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          export NIX_CONFIG="extra-experimental-features = nix-command flakes"
           nix develop --command echo "Nix dev shell ready"
 
       - name: Download forge-artifacts
@@ -130,6 +131,7 @@ jobs:
       - name: Run tests (${{ inputs.group-name }})
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          export NIX_CONFIG="extra-experimental-features = nix-command flakes"
           nix develop --command bash -c '
             go install gotest.tools/gotestsum@latest
             gotestsum --format github-actions -- -timeout 35m -p 1 -count 1 -run '"'"'${{ inputs.tests }}'"'"' ./espresso/devnet-tests/...

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -118,7 +118,7 @@ jobs:
         run: |
           cd espresso
           COMPOSE_PROFILES=tee docker compose build
-          COMPOSE_PROFILES=tee docker compose pull --ignore-buildable
+          COMPOSE_PROFILES=tee docker compose pull --ignore-buildable --ignore-pull-failures
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -57,7 +57,7 @@ jobs:
             sudo shutdown -h +50
 
             # Install libicu — required by the GitHub Actions runner (.NET Core dependency)
-            sudo dnf install -y libicu
+            sudo dnf install -y libicu docker-compose-plugin
 
             # Ensure Docker is running
             sudo systemctl enable --now docker

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -122,13 +122,9 @@ jobs:
           name: devnet-deployment
           path: espresso/deployment/
 
-      - name: Build Docker images
+      - name: Build Docker images (TEE profile)
         run: |
           cd espresso
-          # Build default profile first (op-batcher:espresso, op-geth:espresso, etc.)
-          # then TEE profile (op-batcher-tee, op-batcher-enclave-app).
-          # TEE services like op-batcher-fallback depend on images from the default profile.
-          docker compose build
           COMPOSE_PROFILES=tee docker compose build
           COMPOSE_PROFILES=tee docker compose pull --ignore-buildable
 

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -122,9 +122,13 @@ jobs:
           name: devnet-deployment
           path: espresso/deployment/
 
-      - name: Build Docker images (TEE profile)
+      - name: Build Docker images
         run: |
           cd espresso
+          # Build default profile first (op-batcher:espresso, op-geth:espresso, etc.)
+          # then TEE profile (op-batcher-tee, op-batcher-enclave-app).
+          # TEE services like op-batcher-fallback depend on images from the default profile.
+          docker compose build
           COMPOSE_PROFILES=tee docker compose build
           COMPOSE_PROFILES=tee docker compose pull --ignore-buildable
 

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -55,6 +55,9 @@ jobs:
           run-runner-as-user: ec2-user
           startup-timeout-minutes: 10
           pre-runner-script: |
+            # Install libicu — required by the GitHub Actions runner (.NET Core dependency)
+            sudo dnf install -y libicu
+
             # Ensure Docker is running
             sudo systemctl enable --now docker
             sudo usermod -aG docker ec2-user

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -12,9 +12,9 @@ on:
         required: true
         type: string
     # Secrets (GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID)
-    # are sourced from the tee-testing environment, not passed as workflow inputs.
-    # This keeps the PAT off the EC2 self-hosted runner (only start-runner and
-    # stop-runner jobs reference the environment).
+    # are repository-level secrets. The run-tests job on the EC2 self-hosted runner
+    # does not reference them — only start-runner and stop-runner (on GitHub-hosted
+    # runners) use them.
 
 permissions:
   id-token: write
@@ -24,7 +24,6 @@ jobs:
   start-runner:
     name: Start EC2 runner (${{ inputs.group-name }})
     runs-on: ubuntu-latest
-    environment: tee-testing
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -134,7 +133,6 @@ jobs:
       - start-runner
       - run-tests
     runs-on: ubuntu-latest
-    environment: tee-testing
     if: ${{ always() }}
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/ec2-devnet-test.yaml
+++ b/.github/workflows/ec2-devnet-test.yaml
@@ -52,6 +52,11 @@ jobs:
           run-runner-as-user: ec2-user
           startup-timeout-minutes: 10
           pre-runner-script: |
+            # Safety net: self-terminate after 50 minutes in case the
+            # stop-runner job never fires (workflow cancelled, GitHub outage, etc.).
+            # InstanceInitiatedShutdownBehavior=terminate ensures shutdown = termination.
+            sudo shutdown -h +50
+
             # Install libicu — required by the GitHub Actions runner (.NET Core dependency)
             sudo dnf install -y libicu
 

--- a/.github/workflows/espresso-devnet-tests-tee.yaml
+++ b/.github/workflows/espresso-devnet-tests-tee.yaml
@@ -1,0 +1,126 @@
+name: Run Espresso Devnet tests (TEE)
+
+# Mirrors espresso-devnet-tests.yaml but runs on Nitro-enabled EC2 instances
+# with the TEE compose profile. Each test group gets its own ephemeral EC2
+# runner managed by ec2-github-runner.
+#
+# Prerequisites:
+#   - EspressoSystems/ec2-github-runner fork with enclave-options support
+#   - Repository secrets: GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID
+#   - AMI ami-0d259f3ae020af5f9 (Amazon Linux 2023 with Nix, Docker, nitro-cli)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "celo-integration*"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-contracts:
+    uses: ./.github/workflows/compile-contracts.yaml
+
+  prepare:
+    needs: build-contracts
+    runs-on: ubuntu-24.04-8core
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache submodules
+        uses: ./.github/actions/cache-submodules
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore Nix cache
+        id: cache-nix-restore
+        uses: nix-community/cache-nix-action/restore@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+      - name: Set up Nix environment
+        uses: nicknovitski/nix-develop@v1
+
+      - name: Cache Go modules
+        uses: actions/setup-go@v5
+
+      - name: Download forge-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: forge-artifacts
+          path: packages/contracts-bedrock/forge-artifacts/
+
+      - name: Load environment variables
+        run: |
+          while IFS= read -r line; do
+            # Skip comments and empty lines
+            if [[ ! "$line" =~ ^#.* ]] && [[ -n "$line" ]]; then
+              # Remove quotes from values
+              line=$(echo "$line" | sed 's/"\(.*\)"/\1/')
+              echo "$line" >> $GITHUB_ENV
+            fi
+          done < ./espresso/.env
+        shell: bash
+
+      - name: Build op-deployer and prepare allocs
+        run: |
+          cd op-deployer
+          just
+          export PATH=$PATH:$PWD/bin
+          cd ../espresso
+          ./scripts/prepare-allocs.sh
+
+      - name: Upload deployment artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: devnet-deployment
+          path: espresso/deployment/
+          retention-days: 1
+
+      - name: Save Nix cache
+        uses: nix-community/cache-nix-action/save@v6
+        if: always() && steps.cache-nix-restore.outputs.hit-primary-key != 'true'
+        with:
+          primary-key: ${{ steps.cache-nix-restore.outputs.primary-key }}
+
+  # Each test group runs on its own Nitro-enabled EC2 instance.
+  # TestChallengeGame is excluded — it skips under the TEE profile.
+  # TestChangeBatchAuthenticatorOwner is included; it loads env vars from espresso/.env.
+  tee-group-0:
+    needs: prepare
+    uses: ./.github/workflows/ec2-devnet-test.yaml
+    with:
+      tests: "TestSmoke/tee|TestBatcherRestart/tee"
+      group-name: "group-0"
+    secrets: inherit
+
+  tee-group-1:
+    needs: prepare
+    uses: ./.github/workflows/ec2-devnet-test.yaml
+    with:
+      tests: "TestWithdrawal/tee|TestBatcherSwitching/tee"
+      group-name: "group-1"
+    secrets: inherit
+
+  tee-group-2:
+    needs: prepare
+    uses: ./.github/workflows/ec2-devnet-test.yaml
+    with:
+      tests: "TestForcedTransaction/tee|TestChangeBatchAuthenticatorOwner/tee"
+      group-name: "group-2"
+    secrets: inherit
+
+  tee-group-3:
+    needs: prepare
+    uses: ./.github/workflows/ec2-devnet-test.yaml
+    with:
+      tests: "TestBatcherActivePublishOnly/tee"
+      group-name: "group-3"
+    secrets: inherit

--- a/.github/workflows/espresso-devnet-tests-tee.yaml
+++ b/.github/workflows/espresso-devnet-tests-tee.yaml
@@ -6,7 +6,7 @@ name: Run Espresso Devnet tests (TEE)
 #
 # Prerequisites:
 #   - EspressoSystems/ec2-github-runner fork with enclave-options support
-#   - Environment secrets (tee-testing): GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID
+#   - Repository secrets: GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID
 #   - AMI ami-0d259f3ae020af5f9 (Amazon Linux 2023 with Nix, Docker, nitro-cli)
 
 on:

--- a/.github/workflows/espresso-devnet-tests-tee.yaml
+++ b/.github/workflows/espresso-devnet-tests-tee.yaml
@@ -91,7 +91,7 @@ jobs:
           primary-key: ${{ steps.cache-nix-restore.outputs.primary-key }}
 
   # Each test group runs on its own Nitro-enabled EC2 instance.
-  # TestChallengeGame is excluded — it skips under the TEE profile.
+  # TestChallengeGame and TestWithdrawal are excluded — they require the succinct-proposer, not available in TEE profile.
   # TestChangeBatchAuthenticatorOwner is included; it loads env vars from espresso/.env.
   tee-group-0:
     needs: prepare
@@ -105,7 +105,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/ec2-devnet-test.yaml
     with:
-      tests: "TestWithdrawal/tee|TestBatcherSwitching/tee"
+      tests: "TestBatcherSwitching/tee"
       group-name: "group-1"
     secrets: inherit
 

--- a/.github/workflows/espresso-devnet-tests-tee.yaml
+++ b/.github/workflows/espresso-devnet-tests-tee.yaml
@@ -6,7 +6,7 @@ name: Run Espresso Devnet tests (TEE)
 #
 # Prerequisites:
 #   - EspressoSystems/ec2-github-runner fork with enclave-options support
-#   - Repository secrets: GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID
+#   - Environment secrets (tee-testing): GH_PERSONAL_ACCESS_TOKEN, AWS_EC2_SUBNET_ID, AWS_EC2_SECURITY_GROUP_ID
 #   - AMI ami-0d259f3ae020af5f9 (Amazon Linux 2023 with Nix, Docker, nitro-cli)
 
 on:
@@ -99,7 +99,6 @@ jobs:
     with:
       tests: "TestSmoke/tee|TestBatcherRestart/tee"
       group-name: "group-0"
-    secrets: inherit
 
   tee-group-1:
     needs: prepare
@@ -107,7 +106,6 @@ jobs:
     with:
       tests: "TestWithdrawal/tee|TestBatcherSwitching/tee"
       group-name: "group-1"
-    secrets: inherit
 
   tee-group-2:
     needs: prepare
@@ -115,7 +113,6 @@ jobs:
     with:
       tests: "TestForcedTransaction/tee|TestChangeBatchAuthenticatorOwner/tee"
       group-name: "group-2"
-    secrets: inherit
 
   tee-group-3:
     needs: prepare
@@ -123,4 +120,3 @@ jobs:
     with:
       tests: "TestBatcherActivePublishOnly/tee"
       group-name: "group-3"
-    secrets: inherit

--- a/.github/workflows/espresso-devnet-tests-tee.yaml
+++ b/.github/workflows/espresso-devnet-tests-tee.yaml
@@ -99,6 +99,7 @@ jobs:
     with:
       tests: "TestSmoke/tee|TestBatcherRestart/tee"
       group-name: "group-0"
+    secrets: inherit
 
   tee-group-1:
     needs: prepare
@@ -106,6 +107,7 @@ jobs:
     with:
       tests: "TestWithdrawal/tee|TestBatcherSwitching/tee"
       group-name: "group-1"
+    secrets: inherit
 
   tee-group-2:
     needs: prepare
@@ -113,6 +115,7 @@ jobs:
     with:
       tests: "TestForcedTransaction/tee|TestChangeBatchAuthenticatorOwner/tee"
       group-name: "group-2"
+    secrets: inherit
 
   tee-group-3:
     needs: prepare
@@ -120,3 +123,4 @@ jobs:
     with:
       tests: "TestBatcherActivePublishOnly/tee"
       group-name: "group-3"
+    secrets: inherit

--- a/.github/workflows/espresso-devnet-tests.yaml
+++ b/.github/workflows/espresso-devnet-tests.yaml
@@ -137,7 +137,7 @@ jobs:
         run: |
           cd espresso
           docker compose build
-          COMPOSE_PROFILES=default docker compose pull --ignore-buildable
+          COMPOSE_PROFILES=default docker compose pull --ignore-buildable --ignore-pull-failures
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/espresso-devnet-tests.yaml
+++ b/.github/workflows/espresso-devnet-tests.yaml
@@ -137,7 +137,7 @@ jobs:
         run: |
           cd espresso
           docker compose build
-          COMPOSE_PROFILES=default docker compose pull --ignore-buildable --ignore-pull-failures
+          COMPOSE_PROFILES=default docker compose pull --ignore-buildable
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/espresso-devnet-tests.yaml
+++ b/.github/workflows/espresso-devnet-tests.yaml
@@ -87,7 +87,7 @@ jobs:
           - group: 0
             tests: "TestChallengeGame|TestChangeBatchAuthenticatorOwner"
           - group: 1
-            tests: "TestSmokeWithoutTEE|TestBatcherRestart"
+            tests: "TestSmoke|TestBatcherRestart"
           - group: 2
             tests: "TestWithdrawal|TestBatcherSwitching"
           - group: 3

--- a/espresso/devnet-tests/batcher_active_publish_test.go
+++ b/espresso/devnet-tests/batcher_active_publish_test.go
@@ -48,12 +48,15 @@ func TestBatcherActivePublishOnly(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	// Initialize devnet with FALLBACK profile (starts both batchers)
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	// Send initial transaction to verify everything has started up ok
 	require.NoError(t, d.RunSimpleL2Burn())

--- a/espresso/devnet-tests/batcher_active_publish_test.go
+++ b/espresso/devnet-tests/batcher_active_publish_test.go
@@ -45,101 +45,102 @@ func hasBatchTransactions(ctx context.Context, client *ethclient.Client, batchIn
 
 // TestBatcherActivePublishOnly tests that only the active batcher publishes to L1.
 func TestBatcherActivePublishOnly(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
-	defer cancel()
-
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		defer cancel()
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	// Send initial transaction to verify everything has started up ok
-	require.NoError(t, d.RunSimpleL2Burn())
-	config, err := d.RollupConfig(ctx)
-	require.NoError(t, err)
-
-	l1ChainID, err := d.L1.ChainID(ctx)
-	require.NoError(t, err)
-
-	deployerOpts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Deployer, l1ChainID)
-	require.NoError(t, err)
-
-	batchAuthenticator, err := bindings.NewBatchAuthenticator(config.BatchAuthenticatorAddress, d.L1)
-	require.NoError(t, err)
-
-	espressoBatcherAddr, err := batchAuthenticator.EspressoBatcher(&bind.CallOpts{})
-	require.NoError(t, err)
-	fallbackBatcherAddr := config.Genesis.SystemConfig.BatcherAddr
-
-	activeIsEspresso, err := batchAuthenticator.ActiveIsEspresso(&bind.CallOpts{})
-	require.NoError(t, err)
-	t.Logf("Initial state: activeIsEspresso = %v", activeIsEspresso)
-
-	// verifyPublishing helper function
-	verifyPublishing := func(expectTeeActive bool) {
-		t.Logf("Verifying publishing for state: expectTeeActive=%v", expectTeeActive)
-
-		startBlock, err := d.L1.BlockNumber(ctx)
-		require.NoError(t, err)
-		t.Logf("Starting from block %d", startBlock)
-
-		// Generate L2 traffic
-		burnReceipt, err := d.SubmitSimpleL2Burn()
-		require.NoError(t, err)
-		t.Logf("Generated L2 transaction: %s (L2 block %d)", burnReceipt.Receipt.TxHash, burnReceipt.Receipt.BlockNumber)
-
-		// Wait for batcher to publish
-		// We wait long enough for the active batcher to publish, but not so long that we timeout the test
-		// The idle batcher check inside the driver should prevent it from publishing
-		time.Sleep(60 * time.Second)
-		t.Logf("Waited 60s for L1 confirmation")
-
-		endBlock, err := d.L1.BlockNumber(ctx)
-		require.NoError(t, err)
-		t.Logf("Checking blocks %d-%d", startBlock, endBlock)
-
-		espressoPublished, err := hasBatchTransactions(ctx, d.L1, config.BatchInboxAddress, espressoBatcherAddr, startBlock, endBlock)
-		require.NoError(t, err)
-		fallbackPublished, err := hasBatchTransactions(ctx, d.L1, config.BatchInboxAddress, fallbackBatcherAddr, startBlock, endBlock)
+		// Send initial transaction to verify everything has started up ok
+		require.NoError(t, d.RunSimpleL2Burn())
+		config, err := d.RollupConfig(ctx)
 		require.NoError(t, err)
 
-		t.Logf("Espresso batcher published: %v, fallback batcher published: %v", espressoPublished, fallbackPublished)
+		l1ChainID, err := d.L1.ChainID(ctx)
+		require.NoError(t, err)
 
-		if expectTeeActive {
-			require.True(t, espressoPublished, "Espresso batcher should publish when active")
-			require.False(t, fallbackPublished, "fallback batcher should NOT publish when inactive")
-		} else {
-			require.True(t, fallbackPublished, "fallback batcher should publish when active")
-			require.False(t, espressoPublished, "Espresso batcher should NOT publish when inactive")
+		deployerOpts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Deployer, l1ChainID)
+		require.NoError(t, err)
+
+		batchAuthenticator, err := bindings.NewBatchAuthenticator(config.BatchAuthenticatorAddress, d.L1)
+		require.NoError(t, err)
+
+		espressoBatcherAddr, err := batchAuthenticator.EspressoBatcher(&bind.CallOpts{})
+		require.NoError(t, err)
+		fallbackBatcherAddr := config.Genesis.SystemConfig.BatcherAddr
+
+		activeIsEspresso, err := batchAuthenticator.ActiveIsEspresso(&bind.CallOpts{})
+		require.NoError(t, err)
+		t.Logf("Initial state: activeIsEspresso = %v", activeIsEspresso)
+
+		// verifyPublishing helper function
+		verifyPublishing := func(expectEspressoActive bool) {
+			t.Logf("Verifying publishing for state: expectEspressoActive=%v", expectEspressoActive)
+
+			startBlock, err := d.L1.BlockNumber(ctx)
+			require.NoError(t, err)
+			t.Logf("Starting from block %d", startBlock)
+
+			// Generate L2 traffic
+			burnReceipt, err := d.SubmitSimpleL2Burn()
+			require.NoError(t, err)
+			t.Logf("Generated L2 transaction: %s (L2 block %d)", burnReceipt.Receipt.TxHash, burnReceipt.Receipt.BlockNumber)
+
+			// Wait for batcher to publish
+			// We wait long enough for the active batcher to publish, but not so long that we timeout the test
+			// The idle batcher check inside the driver should prevent it from publishing
+			time.Sleep(60 * time.Second)
+			t.Logf("Waited 60s for L1 confirmation")
+
+			endBlock, err := d.L1.BlockNumber(ctx)
+			require.NoError(t, err)
+			t.Logf("Checking blocks %d-%d", startBlock, endBlock)
+
+			espressoPublished, err := hasBatchTransactions(ctx, d.L1, config.BatchInboxAddress, espressoBatcherAddr, startBlock, endBlock)
+			require.NoError(t, err)
+			fallbackPublished, err := hasBatchTransactions(ctx, d.L1, config.BatchInboxAddress, fallbackBatcherAddr, startBlock, endBlock)
+			require.NoError(t, err)
+
+			t.Logf("Espresso batcher published: %v, fallback batcher published: %v", espressoPublished, fallbackPublished)
+
+			if expectEspressoActive {
+				require.True(t, espressoPublished, "Espresso batcher should publish when active")
+				require.False(t, fallbackPublished, "fallback batcher should NOT publish when inactive")
+			} else {
+				require.True(t, fallbackPublished, "fallback batcher should publish when active")
+				require.False(t, espressoPublished, "Espresso batcher should NOT publish when inactive")
+			}
 		}
-	}
 
-	// 1. Verify initial state
-	verifyPublishing(activeIsEspresso)
+		// 1. Verify initial state
+		verifyPublishing(activeIsEspresso)
 
-	// 2. Switch state
-	t.Logf("Switching batcher state...")
-	switchTx, err := batchAuthenticator.SwitchBatcher(deployerOpts)
-	require.NoError(t, err)
-	receipt, err := wait.ForReceiptOK(ctx, d.L1, switchTx.Hash())
-	require.NoError(t, err)
-	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+		// 2. Switch state
+		t.Logf("Switching batcher state...")
+		switchTx, err := batchAuthenticator.SwitchBatcher(deployerOpts)
+		require.NoError(t, err)
+		receipt, err := wait.ForReceiptOK(ctx, d.L1, switchTx.Hash())
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-	// Update expected state
-	activeIsEspresso = !activeIsEspresso
-	t.Logf("Switched state to: activeIsEspresso=%v", activeIsEspresso)
+		// Update expected state
+		activeIsEspresso = !activeIsEspresso
+		t.Logf("Switched state to: activeIsEspresso=%v", activeIsEspresso)
 
-	// Wait for services to stabilize after switch. In-flight sendTxWithEspresso goroutines
-	// spawned before deactivation can take ~25s to drain their queued Txmgr.Send calls,
-	// so we wait long enough for all residual transactions to land on L1 before capturing
-	// startBlock in the next verifyPublishing call.
-	time.Sleep(60 * time.Second)
+		// Wait for services to stabilize after switch. In-flight sendTxWithEspresso goroutines
+		// spawned before deactivation can take ~25s to drain their queued Txmgr.Send calls,
+		// so we wait long enough for all residual transactions to land on L1 before capturing
+		// startBlock in the next verifyPublishing call.
+		time.Sleep(60 * time.Second)
 
-	// 3. Verify new state
-	verifyPublishing(activeIsEspresso)
+		// 3. Verify new state
+		verifyPublishing(activeIsEspresso)
+	})
 }

--- a/espresso/devnet-tests/batcher_restart_test.go
+++ b/espresso/devnet-tests/batcher_restart_test.go
@@ -8,40 +8,41 @@ import (
 )
 
 func TestBatcherRestart(t *testing.T) {
-	ctx := t.Context()
-
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		ctx := t.Context()
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	// Send a transaction just to check that everything has started up ok.
-	require.NoError(t, d.RunSimpleL2Burn())
+		// Send a transaction just to check that everything has started up ok.
+		require.NoError(t, d.RunSimpleL2Burn())
 
-	// Shut down the batcher and have another transaction submitted while it is down.
-	require.NoError(t, d.ServiceDown(OpBatcher))
-	d.SleepOutageDuration()
+		// Shut down the batcher and have another transaction submitted while it is down.
+		require.NoError(t, d.ServiceDown(OpBatcher))
+		d.SleepOutageDuration()
 
-	receipt, err := d.SubmitSimpleL2Burn()
-	require.NoError(t, err)
+		receipt, err := d.SubmitSimpleL2Burn()
+		require.NoError(t, err)
 
-	// Check that while the batcher is down, the verifier does NOT process submitted transactions.
-	d.SleepOutageDuration()
-	_, err = d.L2Verif.TransactionReceipt(ctx, receipt.Receipt.TxHash)
-	require.ErrorIs(t, err, ethereum.NotFound)
+		// Check that while the batcher is down, the verifier does NOT process submitted transactions.
+		d.SleepOutageDuration()
+		_, err = d.L2Verif.TransactionReceipt(ctx, receipt.Receipt.TxHash)
+		require.ErrorIs(t, err, ethereum.NotFound)
 
-	// Bring the batcher back up and check that it processes the transaction which was submitted
-	// while it was down.
-	require.NoError(t, d.ServiceUp(OpBatcher))
-	require.NoError(t, d.WaitForBatcher(ctx, t))
-	require.NoError(t, d.VerifySimpleL2Burn(receipt))
+		// Bring the batcher back up and check that it processes the transaction which was submitted
+		// while it was down.
+		require.NoError(t, d.ServiceUp(OpBatcher))
+		require.NoError(t, d.WaitForBatcher(ctx))
+		require.NoError(t, d.VerifySimpleL2Burn(receipt))
 
-	// Submit another transaction at the end just to check that things stay working.
-	d.SleepRecoveryDuration()
-	require.NoError(t, d.RunSimpleL2Burn())
+		// Submit another transaction at the end just to check that things stay working.
+		d.SleepRecoveryDuration()
+		require.NoError(t, d.RunSimpleL2Burn())
+	})
 }

--- a/espresso/devnet-tests/batcher_restart_test.go
+++ b/espresso/devnet-tests/batcher_restart_test.go
@@ -1,7 +1,6 @@
 package devnet_tests
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
@@ -9,20 +8,23 @@ import (
 )
 
 func TestBatcherRestart(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	// Send a transaction just to check that everything has started up ok.
 	require.NoError(t, d.RunSimpleL2Burn())
 
 	// Shut down the batcher and have another transaction submitted while it is down.
-	require.NoError(t, d.ServiceDown("op-batcher"))
+	require.NoError(t, d.ServiceDown(OpBatcher))
 	d.SleepOutageDuration()
 
 	receipt, err := d.SubmitSimpleL2Burn()
@@ -35,7 +37,8 @@ func TestBatcherRestart(t *testing.T) {
 
 	// Bring the batcher back up and check that it processes the transaction which was submitted
 	// while it was down.
-	require.NoError(t, d.ServiceUp("op-batcher"))
+	require.NoError(t, d.ServiceUp(OpBatcher))
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 	require.NoError(t, d.VerifySimpleL2Burn(receipt))
 
 	// Submit another transaction at the end just to check that things stay working.

--- a/espresso/devnet-tests/batcher_switching_test.go
+++ b/espresso/devnet-tests/batcher_switching_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBatcherSwitching tests that the batcher can be switched from the Espresso
-// batcher to a fallback batcher using the BatchAuthenticator contract.
+// TestBatcherSwitching tests that the batcher can be switched from the TEE-enabled
+// batcher to a fallback non-TEE batcher using the BatchAuthenticator contract.
 //
 // This is the devnet equivalent of TestBatcherSwitching from the E2E tests.
 // The test runs two batchers in parallel:
@@ -21,12 +21,15 @@ func TestBatcherSwitching(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Initialize devnet with FALLBACK profile (starts both batchers)
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	// Send initial transaction to verify everything has started up ok
 	require.NoError(t, d.RunSimpleL2Burn())
@@ -52,9 +55,15 @@ func TestBatcherSwitching(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Before switch: activeIsEspresso = %v", activeIsEspresso)
 
-	// Stop the Espresso batcher (op-batcher with Espresso enabled)
-	require.NoError(t, d.StopBatcherSubmitting("op-batcher"))
-	t.Logf("Stopped op-batcher batch submission")
+	// Stop the primary batcher.  In TEE mode the admin RPC is not reachable
+	// from outside the enclave, so we kill the container instead.
+	if profile == TEE {
+		require.NoError(t, d.ServiceDown(OpBatcher))
+		t.Logf("Killed op-batcher-tee container")
+	} else {
+		require.NoError(t, d.StopBatcherSubmitting(OpBatcher))
+		t.Logf("Stopped op-batcher batch submission via admin RPC")
+	}
 
 	// Switch active batcher via BatchAuthenticator contract
 	tx, err := batchAuthenticator.SwitchBatcher(deployerOpts)
@@ -73,7 +82,7 @@ func TestBatcherSwitching(t *testing.T) {
 	t.Logf("After switch: activeIsEspresso = %v", activeIsEspressoAfter)
 
 	// Start the fallback batcher
-	require.NoError(t, d.StartBatcherSubmitting("op-batcher-fallback"))
+	require.NoError(t, d.StartBatcherSubmitting(OpBatcherFallback))
 	t.Logf("Started op-batcher-fallback batch submission")
 
 	// Verify everything still works with the fallback batcher

--- a/espresso/devnet-tests/batcher_switching_test.go
+++ b/espresso/devnet-tests/batcher_switching_test.go
@@ -10,87 +10,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBatcherSwitching tests that the batcher can be switched from the TEE-enabled
-// batcher to a fallback non-TEE batcher using the BatchAuthenticator contract.
+// TestBatcherSwitching tests that the batcher can be switched from the Espresso
+// batcher to a fallback batcher using the BatchAuthenticator contract.
 //
 // This is the devnet equivalent of TestBatcherSwitching from the E2E tests.
 // The test runs two batchers in parallel:
 // - op-batcher: The primary batcher with Espresso enabled (initially active)
 // - op-batcher-fallback: The fallback batcher without Espresso (initially stopped)
 func TestBatcherSwitching(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	// Send initial transaction to verify everything has started up ok
-	require.NoError(t, d.RunSimpleL2Burn())
+		// Send initial transaction to verify everything has started up ok
+		require.NoError(t, d.RunSimpleL2Burn())
 
-	// Get rollup config to access BatchAuthenticator address
-	config, err := d.RollupConfig(ctx)
-	require.NoError(t, err)
+		// Get rollup config to access BatchAuthenticator address
+		config, err := d.RollupConfig(ctx)
+		require.NoError(t, err)
 
-	// Get L1 chain ID for transaction signing
-	l1ChainID, err := d.L1.ChainID(ctx)
-	require.NoError(t, err)
+		// Get L1 chain ID for transaction signing
+		l1ChainID, err := d.L1.ChainID(ctx)
+		require.NoError(t, err)
 
-	// Create transactor options using the deployer key (owner of BatchAuthenticator)
-	deployerOpts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Deployer, l1ChainID)
-	require.NoError(t, err)
+		// Create transactor options using the deployer key (owner of BatchAuthenticator)
+		deployerOpts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Deployer, l1ChainID)
+		require.NoError(t, err)
 
-	// Bind to BatchAuthenticator contract
-	batchAuthenticator, err := bindings.NewBatchAuthenticator(config.BatchAuthenticatorAddress, d.L1)
-	require.NoError(t, err)
+		// Bind to BatchAuthenticator contract
+		batchAuthenticator, err := bindings.NewBatchAuthenticator(config.BatchAuthenticatorAddress, d.L1)
+		require.NoError(t, err)
 
-	// Check current active batcher state before switching
-	activeIsEspresso, err := batchAuthenticator.ActiveIsEspresso(&bind.CallOpts{})
-	require.NoError(t, err)
-	t.Logf("Before switch: activeIsEspresso = %v", activeIsEspresso)
+		// Check current active batcher state before switching
+		activeIsEspresso, err := batchAuthenticator.ActiveIsEspresso(&bind.CallOpts{})
+		require.NoError(t, err)
+		t.Logf("Before switch: activeIsEspresso = %v", activeIsEspresso)
 
-	// Stop the primary batcher.  In TEE mode the admin RPC is not reachable
-	// from outside the enclave, so we kill the container instead.
-	if profile == TEE {
-		require.NoError(t, d.ServiceDown(OpBatcher))
-		t.Logf("Killed op-batcher-tee container")
-	} else {
-		require.NoError(t, d.StopBatcherSubmitting(OpBatcher))
-		t.Logf("Stopped op-batcher batch submission via admin RPC")
-	}
+		// Stop the primary batcher.  In TEE mode the admin RPC is not reachable
+		// from outside the enclave, so we kill the container instead.
+		if profile == TEE {
+			require.NoError(t, d.ServiceDown(OpBatcher))
+			t.Logf("Killed op-batcher-tee container")
+		} else {
+			require.NoError(t, d.StopBatcherSubmitting(OpBatcher))
+			t.Logf("Stopped op-batcher batch submission via admin RPC")
+		}
 
-	// Switch active batcher via BatchAuthenticator contract
-	tx, err := batchAuthenticator.SwitchBatcher(deployerOpts)
-	require.NoError(t, err)
-	t.Logf("Submitted switchBatcher transaction: %s", tx.Hash().Hex())
+		// Switch active batcher via BatchAuthenticator contract
+		tx, err := batchAuthenticator.SwitchBatcher(deployerOpts)
+		require.NoError(t, err)
+		t.Logf("Submitted switchBatcher transaction: %s", tx.Hash().Hex())
 
-	// Wait for transaction receipt
-	receipt, err := wait.ForReceiptOK(ctx, d.L1, tx.Hash())
-	require.NoError(t, err)
-	t.Logf("SwitchBatcher transaction confirmed in block %d", receipt.BlockNumber.Uint64())
+		// Wait for transaction receipt
+		receipt, err := wait.ForReceiptOK(ctx, d.L1, tx.Hash())
+		require.NoError(t, err)
+		t.Logf("SwitchBatcher transaction confirmed in block %d", receipt.BlockNumber.Uint64())
 
-	// Verify the switch happened
-	activeIsEspressoAfter, err := batchAuthenticator.ActiveIsEspresso(&bind.CallOpts{})
-	require.NoError(t, err)
-	require.NotEqual(t, activeIsEspresso, activeIsEspressoAfter, "activeIsEspresso should have toggled")
-	t.Logf("After switch: activeIsEspresso = %v", activeIsEspressoAfter)
+		// Verify the switch happened
+		activeIsEspressoAfter, err := batchAuthenticator.ActiveIsEspresso(&bind.CallOpts{})
+		require.NoError(t, err)
+		require.NotEqual(t, activeIsEspresso, activeIsEspressoAfter, "activeIsEspresso should have toggled")
+		t.Logf("After switch: activeIsEspresso = %v", activeIsEspressoAfter)
 
-	// Start the fallback batcher
-	require.NoError(t, d.StartBatcherSubmitting(OpBatcherFallback))
-	t.Logf("Started op-batcher-fallback batch submission")
+		// Start the fallback batcher
+		require.NoError(t, d.StartBatcherSubmitting(OpBatcherFallback))
+		t.Logf("Started op-batcher-fallback batch submission")
 
-	// Verify everything still works with the fallback batcher
-	require.NoError(t, d.RunSimpleL2Burn())
-	t.Logf("Transaction verified with fallback batcher")
+		// Verify everything still works with the fallback batcher
+		require.NoError(t, d.RunSimpleL2Burn())
+		t.Logf("Transaction verified with fallback batcher")
 
-	// Submit another transaction and verify system continues to work
-	d.SleepRecoveryDuration()
-	require.NoError(t, d.RunSimpleL2Burn())
-	t.Logf("System continues to work after batcher switch")
+		// Submit another transaction and verify system continues to work
+		d.SleepRecoveryDuration()
+		require.NoError(t, d.RunSimpleL2Burn())
+		t.Logf("System continues to work after batcher switch")
+	})
 }

--- a/espresso/devnet-tests/challenge_test.go
+++ b/espresso/devnet-tests/challenge_test.go
@@ -15,99 +15,101 @@ import (
 // and that games can be queried from the DisputeGameFactory contract.
 // The succinct proposer needs finalized L2 blocks before creating games.
 func TestChallengeGame(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	profile := ProfileFromEnv(t)
-	if profile == TEE {
-		t.Skip("challenge test requires succinct-proposer/challenger, not available in TEE profile")
-	}
-
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
-
-	require.NoError(t, d.WaitForBatcher(ctx, t))
-
-	// Verify devnet is running and generate some L2 activity
-	require.NoError(t, d.RunSimpleL2Burn())
-
-	// Wait a bit for blocks to be produced and batched
-	t.Log("Waiting for blocks to be produced and batched...")
-	time.Sleep(10 * time.Second)
-
-	// Wait for the succinct proposer to create a dispute game
-	// The proposer creates games when safe L2 head >= anchor + proposal_interval (3 blocks)
-	t.Log("Waiting for succinct-proposer to create a dispute game...")
-	var games []ChallengeGame
-	maxGameWait := 2 * time.Minute
-	gameWaitStart := time.Now()
-
-	for len(games) == 0 {
-		if time.Since(gameWaitStart) > maxGameWait {
-			t.Fatalf("timeout waiting for dispute game to be created (waited %v)", maxGameWait)
+	t.Run(string(profile), func(t *testing.T) {
+		if profile == TEE {
+			t.Skip("challenge test requires succinct-proposer/challenger, not available in TEE profile")
 		}
 
-		t.Logf("waiting for a challenge game to be created by succinct-proposer...")
-		time.Sleep(5 * time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		var err error
-		games, err = d.ListChallengeGames()
-		if err != nil {
-			t.Logf("error listing games (will retry): %v", err)
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
+
+		require.NoError(t, d.WaitForBatcher(ctx))
+
+		// Verify devnet is running and generate some L2 activity
+		require.NoError(t, d.RunSimpleL2Burn())
+
+		// Wait a bit for blocks to be produced and batched
+		t.Log("Waiting for blocks to be produced and batched...")
+		time.Sleep(10 * time.Second)
+
+		// Wait for the succinct proposer to create a dispute game
+		// The proposer creates games when safe L2 head >= anchor + proposal_interval (3 blocks)
+		t.Log("Waiting for succinct-proposer to create a dispute game...")
+		var games []ChallengeGame
+		maxGameWait := 2 * time.Minute
+		gameWaitStart := time.Now()
+
+		for len(games) == 0 {
+			if time.Since(gameWaitStart) > maxGameWait {
+				t.Fatalf("timeout waiting for dispute game to be created (waited %v)", maxGameWait)
+			}
+
+			t.Logf("waiting for a challenge game to be created by succinct-proposer...")
+			time.Sleep(5 * time.Second)
+
+			var err error
+			games, err = d.ListChallengeGames()
+			if err != nil {
+				t.Logf("error listing games (will retry): %v", err)
+			}
 		}
-	}
 
-	t.Logf("game created: index=%d, address=%s, claims=%d",
-		games[0].Index, games[0].Address.Hex(), games[0].Claims)
+		t.Logf("game created: index=%d, address=%s, claims=%d",
+			games[0].Index, games[0].Address.Hex(), games[0].Claims)
 
-	// Verify the game has at least 1 claim (the root claim from proposer)
-	require.GreaterOrEqual(t, games[0].Claims, uint64(1), "Game should have at least 1 claim")
+		// Verify the game has at least 1 claim (the root claim from proposer)
+		require.GreaterOrEqual(t, games[0].Claims, uint64(1), "Game should have at least 1 claim")
 
-	// Bind the dispute game contract and log its initial status.
-	disputeGame, err := bindings.NewFaultDisputeGame(games[0].Address, d.L1)
-	require.NoError(t, err)
-	statusRaw, err := disputeGame.Status(&bind.CallOpts{})
-	require.NoError(t, err)
-	gameStatus, err := types.GameStatusFromUint8(statusRaw)
-	require.NoError(t, err)
-	t.Logf("dispute game initial status: %s (%d)", gameStatus.String(), statusRaw)
-	require.Equal(t, types.GameStatusInProgress, gameStatus, "Dispute game should start InProgress")
-
-	// Observe the dispute game for a limited time to see if it resolves.
-	maxObservation := 15 * time.Minute
-	pollInterval := 10 * time.Second
-	waitStart := time.Now()
-	finalStatus := gameStatus
-	finalStatusRaw := statusRaw
-
-	t.Logf("Observing dispute game %s for up to %s to see if it resolves...", games[0].Address.Hex(), maxObservation)
-
-	for time.Since(waitStart) < maxObservation {
+		// Bind the dispute game contract and log its initial status.
+		disputeGame, err := bindings.NewFaultDisputeGame(games[0].Address, d.L1)
+		require.NoError(t, err)
 		statusRaw, err := disputeGame.Status(&bind.CallOpts{})
 		require.NoError(t, err)
-		status, err := types.GameStatusFromUint8(statusRaw)
+		gameStatus, err := types.GameStatusFromUint8(statusRaw)
 		require.NoError(t, err)
+		t.Logf("dispute game initial status: %s (%d)", gameStatus.String(), statusRaw)
+		require.Equal(t, types.GameStatusInProgress, gameStatus, "Dispute game should start InProgress")
 
-		finalStatus = status
-		finalStatusRaw = statusRaw
+		// Observe the dispute game for a limited time to see if it resolves.
+		maxObservation := 15 * time.Minute
+		pollInterval := 10 * time.Second
+		waitStart := time.Now()
+		finalStatus := gameStatus
+		finalStatusRaw := statusRaw
 
-		if status != types.GameStatusInProgress {
-			t.Logf("dispute game resolved during observation window: %s (%d)", status.String(), statusRaw)
-			require.Equal(t, types.GameStatusDefenderWon, status, "Expected honest proposer/defender to win succinct dispute game")
-			break
+		t.Logf("Observing dispute game %s for up to %s to see if it resolves...", games[0].Address.Hex(), maxObservation)
+
+		for time.Since(waitStart) < maxObservation {
+			statusRaw, err := disputeGame.Status(&bind.CallOpts{})
+			require.NoError(t, err)
+			status, err := types.GameStatusFromUint8(statusRaw)
+			require.NoError(t, err)
+
+			finalStatus = status
+			finalStatusRaw = statusRaw
+
+			if status != types.GameStatusInProgress {
+				t.Logf("dispute game resolved during observation window: %s (%d)", status.String(), statusRaw)
+				require.Equal(t, types.GameStatusDefenderWon, status, "Expected honest proposer/defender to win succinct dispute game")
+				break
+			}
+
+			time.Sleep(pollInterval)
 		}
 
-		time.Sleep(pollInterval)
-	}
+		t.Logf("dispute game observed final status after %s: %s (%d)", time.Since(waitStart), finalStatus.String(), finalStatusRaw)
+		require.Equal(t, finalStatus, types.GameStatusDefenderWon,
+			"succinct dispute game final status must be DefenderWon, got %s (%d)",
+			finalStatus.String(), finalStatusRaw,
+		)
 
-	t.Logf("dispute game observed final status after %s: %s (%d)", time.Since(waitStart), finalStatus.String(), finalStatusRaw)
-	require.Equal(t, finalStatus, types.GameStatusDefenderWon,
-		"succinct dispute game final status must be DefenderWon, got %s (%d)",
-		finalStatus.String(), finalStatusRaw,
-	)
-
-	t.Logf("TestChallengeGame passed: dispute game successfully created by succinct-proposer")
+		t.Logf("TestChallengeGame passed: dispute game successfully created by succinct-proposer")
+	})
 }

--- a/espresso/devnet-tests/challenge_test.go
+++ b/espresso/devnet-tests/challenge_test.go
@@ -18,11 +18,18 @@ func TestChallengeGame(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+	if profile == TEE {
+		t.Skip("challenge test requires succinct-proposer/challenger, not available in TEE profile")
+	}
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	// Verify devnet is running and generate some L2 activity
 	require.NoError(t, d.RunSimpleL2Burn())

--- a/espresso/devnet-tests/challenge_test.go
+++ b/espresso/devnet-tests/challenge_test.go
@@ -75,7 +75,8 @@ func TestChallengeGame(t *testing.T) {
 		gameStatus, err := types.GameStatusFromUint8(statusRaw)
 		require.NoError(t, err)
 		t.Logf("dispute game initial status: %s (%d)", gameStatus.String(), statusRaw)
-		require.Equal(t, types.GameStatusInProgress, gameStatus, "Dispute game should start InProgress")
+		require.True(t, gameStatus == types.GameStatusInProgress || gameStatus == types.GameStatusDefenderWon,
+			"Dispute game should be InProgress or DefenderWon, got %s (%d)", gameStatus.String(), statusRaw)
 
 		// Observe the dispute game for a limited time to see if it resolves.
 		maxObservation := 15 * time.Minute

--- a/espresso/devnet-tests/devnet_tools.go
+++ b/espresso/devnet-tests/devnet_tools.go
@@ -126,7 +126,7 @@ func (d *Devnet) isRunning() bool {
 	return len(out) > 0
 }
 
-// The setting for `COMPOES_PROFILES` when running the Docker Compose.
+// The setting for `COMPOSE_PROFILES` when running the Docker Compose.
 type ComposeProfile string
 
 const (
@@ -449,12 +449,6 @@ func (d *Devnet) SubmitL2Tx(applyTxOpts helpers.TxOptsFn) (*types.Receipt, error
 func (d *Devnet) VerifyL2Tx(receipt *types.Receipt) error {
 	// Use longer timeout in CI environments due to Espresso processing delays
 	timeout := 5 * time.Minute
-
-	// Check if running in CI environment
-	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
-		timeout = 5 * time.Minute
-		log.Info("CI environment detected, using extended timeout for transaction verification", "hash", receipt.TxHash, "timeout", timeout)
-	}
 
 	ctx, cancel := context.WithTimeout(d.ctx, timeout)
 	defer cancel()

--- a/espresso/devnet-tests/devnet_tools.go
+++ b/espresso/devnet-tests/devnet_tools.go
@@ -260,7 +260,7 @@ func (d *Devnet) Up() (err error) {
 
 	return nil
 }
-func (d *Devnet) WaitForBatcher(ctx context.Context, t *testing.T) error {
+func (d *Devnet) WaitForBatcher(ctx context.Context) error {
 	safeBlockNumber := big.NewInt(rpc.SafeBlockNumber.Int64())
 
 	current, err := d.L2Verif.BlockByNumber(ctx, safeBlockNumber)
@@ -298,7 +298,7 @@ func (d *Devnet) WaitForBatcher(ctx context.Context, t *testing.T) error {
 				}
 				return err
 			}
-			if next.Number().Cmp(currentNum) == 1 {
+			if next.Number().Cmp(currentNum) > 0 {
 				return nil
 			}
 			time.Sleep(500 * time.Millisecond)

--- a/espresso/devnet-tests/devnet_tools.go
+++ b/espresso/devnet-tests/devnet_tools.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -13,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,9 +30,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/joho/godotenv"
 
-	env "github.com/ethereum-optimism/optimism/espresso/environment"
+	"github.com/ethereum-optimism/optimism/espresso/environment"
 	"github.com/ethereum-optimism/optimism/op-e2e/config/secrets"
 )
 
@@ -39,6 +42,7 @@ type Devnet struct {
 	secrets       secrets.Secrets
 	outageTime    time.Duration
 	successTime   time.Duration
+	profile       ComposeProfile
 	L1            *ethclient.Client
 	L2Seq         *ethclient.Client
 	L2SeqRollup   *sources.RollupClient
@@ -58,7 +62,21 @@ func LoadDevnetEnv() error {
 	return LoadEnvFile(envPath)
 }
 
-func NewDevnet(ctx context.Context, t *testing.T) *Devnet {
+// Determine appropriate ComposeProfile based on the environment
+func ProfileFromEnv(t *testing.T) ComposeProfile {
+	hasTee, err := environment.HasTee()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasTee {
+		t.Log("Host has nitro enclave support and enclave tests were requested, running in TEE mode")
+		return TEE
+	}
+	t.Log("Running in NON_TEE mode")
+	return NON_TEE
+}
+
+func NewDevnet(ctx context.Context, t *testing.T, profile ComposeProfile) *Devnet {
 
 	if testing.Short() {
 		t.Skip("skipping devnet test in short mode")
@@ -66,6 +84,7 @@ func NewDevnet(ctx context.Context, t *testing.T) *Devnet {
 
 	d := new(Devnet)
 	d.ctx = ctx
+	d.profile = profile
 
 	mnemonics := *secrets.DefaultMnemonicConfig
 	secrets, err := mnemonics.Secrets()
@@ -96,10 +115,7 @@ func NewDevnet(ctx context.Context, t *testing.T) *Devnet {
 }
 
 func (d *Devnet) isRunning() bool {
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "ps", "-q",
-	)
+	cmd := d.composeCommand("ps", "-q")
 	buf := new(bytes.Buffer)
 	cmd.Stdout = buf
 	if err := cmd.Run(); err != nil {
@@ -114,11 +130,64 @@ func (d *Devnet) isRunning() bool {
 type ComposeProfile string
 
 const (
-	ESPRESSO ComposeProfile = "tee"
-	FALLBACK ComposeProfile = "default"
+	TEE     ComposeProfile = "tee"
+	NON_TEE ComposeProfile = "default"
 )
 
-func (d *Devnet) Up(profile ComposeProfile) (err error) {
+// Service identifies a Docker Compose service. Services whose name varies by
+// profile (e.g. the batcher) resolve to the correct container name via Name().
+type Service int
+
+const (
+	OpBatcher         Service = iota // op-batcher (default) / op-batcher-tee (tee)
+	OpBatcherFallback                // op-batcher-fallback
+	OpNodeSequencer                  // op-node-sequencer
+	OpGethSequencer                  // op-geth-sequencer
+	OpNodeVerifier                   // op-node-verifier
+	OpGethVerifier                   // op-geth-verifier
+	L1Anvil                          // l1-anvil
+	OpChallenger                     // op-challenger
+)
+
+// Name returns the Docker Compose service name for the given profile.
+func (s Service) Name(profile ComposeProfile) string {
+	switch s {
+	case OpBatcher:
+		if profile == TEE {
+			return "op-batcher-tee"
+		}
+		return "op-batcher"
+	case OpBatcherFallback:
+		return "op-batcher-fallback"
+	case OpNodeSequencer:
+		return "op-node-sequencer"
+	case OpGethSequencer:
+		return "op-geth-sequencer"
+	case OpNodeVerifier:
+		return "op-node-verifier"
+	case OpGethVerifier:
+		return "op-geth-verifier"
+	case L1Anvil:
+		return "l1-anvil"
+	case OpChallenger:
+		return "op-challenger"
+	default:
+		panic(fmt.Sprintf("unknown service: %d", s))
+	}
+}
+
+// composeCommand creates an exec.Cmd for a docker compose invocation with the
+// correct COMPOSE_PROFILES and OP_BATCHER_PRIVATE_KEY environment variables set.
+func (d *Devnet) composeCommand(args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(d.ctx, "docker", append([]string{"compose"}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"COMPOSE_PROFILES="+string(d.profile),
+		fmt.Sprintf("OP_BATCHER_PRIVATE_KEY=%s", hex.EncodeToString(crypto.FromECDSA(d.secrets.AccountAtIdx(6)))),
+	)
+	return cmd
+}
+
+func (d *Devnet) Up() (err error) {
 	if d.isRunning() {
 		if err := d.Down(); err != nil {
 			return err
@@ -128,16 +197,7 @@ func (d *Devnet) Up(profile ComposeProfile) (err error) {
 		return fmt.Errorf("devnet is already running, this should be a clean state; please shut it down first")
 	}
 
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "up", "-d",
-	)
-	cmd.Env = append(os.Environ(), "COMPOSE_PROFILES="+string(profile))
-	// Espresso batcher uses HD index 6 (distinct from the SystemConfig/fallback batcher at index 2)
-	cmd.Env = append(
-		cmd.Env,
-		fmt.Sprintf("OP_BATCHER_PRIVATE_KEY=%s", hex.EncodeToString(crypto.FromECDSA(d.secrets.AccountAtIdx(6)))),
-	)
+	cmd := d.composeCommand("up", "-d")
 	buf := new(bytes.Buffer)
 	cmd.Stderr = buf
 	if err := cmd.Run(); err != nil {
@@ -167,7 +227,7 @@ func (d *Devnet) Up(profile ComposeProfile) (err error) {
 		// Stream logs to stdout while the test runs. This goroutine will automatically exit when
 		// the context is cancelled.
 		go func() {
-			cmd = exec.CommandContext(d.ctx, "docker", "compose", "logs", "-f")
+			cmd = d.composeCommand("logs", "-f")
 			cmd.Stdout = os.Stdout
 			// We don't care about the error return of this command, since it's always going to be
 			// killed by the context cancellation.
@@ -176,50 +236,89 @@ func (d *Devnet) Up(profile ComposeProfile) (err error) {
 	}
 
 	// Open RPC clients for the different nodes.
-	d.L2Seq, err = d.serviceClient("op-geth-sequencer", 8546)
+	d.L2Seq, err = d.serviceClient(OpGethSequencer, 8546)
 	if err != nil {
 		return err
 	}
-	d.L2SeqRollup, err = d.rollupClient("op-node-sequencer", 9545)
+	d.L2SeqRollup, err = d.rollupClient(OpNodeSequencer, 9545)
 	if err != nil {
 		return err
 	}
-	d.L2Verif, err = d.serviceClient("op-geth-verifier", 8546)
+	d.L2Verif, err = d.serviceClient(OpGethVerifier, 8546)
 	if err != nil {
 		return err
 	}
-	d.L2VerifRollup, err = d.rollupClient("op-node-verifier", 9546)
+	d.L2VerifRollup, err = d.rollupClient(OpNodeVerifier, 9546)
 	if err != nil {
 		return err
 	}
 
-	d.L1, err = d.serviceClient("l1-geth", 8545)
+	d.L1, err = d.serviceClient(L1Anvil, 8545)
 	if err != nil {
 		return err
 	}
 
 	return nil
 }
+func (d *Devnet) WaitForBatcher(ctx context.Context, t *testing.T) error {
+	safeBlockNumber := big.NewInt(rpc.SafeBlockNumber.Int64())
 
-func (d *Devnet) ServiceUp(service string) error {
-	log.Info("bringing up service", "service", service)
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "up", "-d", service,
-	)
-	return cmd.Run()
+	current, err := d.L2Verif.BlockByNumber(ctx, safeBlockNumber)
+	var currentNum *big.Int
+	if err != nil {
+		// If safe block is not found, we're waiting for the first safe block
+		if !strings.Contains(err.Error(), "block not found") {
+			return err
+		}
+		currentNum = big.NewInt(0)
+	} else {
+		currentNum = current.Number()
+	}
+
+	timeout := 2 * time.Minute
+
+	// TEE Batcher takes a long time to start
+	if d.profile == TEE {
+		timeout = 10 * time.Minute
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return timeoutCtx.Err()
+		default:
+			next, err := d.L2Verif.BlockByNumber(timeoutCtx, safeBlockNumber)
+			if err != nil {
+				// If block is not found, keep wait loop running.
+				if strings.Contains(err.Error(), "block not found") {
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+				return err
+			}
+			if next.Number().Cmp(currentNum) == 1 {
+				return nil
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
 }
 
-func (d *Devnet) ServiceDown(service string) error {
-	log.Info("shutting down service", "service", service)
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "down", service,
-	)
-	return cmd.Run()
+func (d *Devnet) ServiceUp(service Service) error {
+	name := service.Name(d.profile)
+	log.Info("bringing up service", "service", name)
+	return d.composeCommand("up", "-d", name).Run()
 }
 
-func (d *Devnet) ServiceRestart(service string) error {
+func (d *Devnet) ServiceDown(service Service) error {
+	name := service.Name(d.profile)
+	log.Info("shutting down service", "service", name)
+	return d.composeCommand("down", name).Run()
+}
+
+func (d *Devnet) ServiceRestart(service Service) error {
 	if err := d.ServiceDown(service); err != nil {
 		return err
 	}
@@ -230,10 +329,10 @@ func (d *Devnet) ServiceRestart(service string) error {
 }
 
 // callBatcherRPC calls a batcher RPC method on a running batcher service
-func (d *Devnet) callBatcherRPC(service, method string) error {
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "exec", "-T", service,
+func (d *Devnet) callBatcherRPC(service Service, method string) error {
+	name := service.Name(d.profile)
+	cmd := d.composeCommand(
+		"exec", "-T", name,
 		"sh", "-c",
 		fmt.Sprintf("wget -q -O- --header='Content-Type: application/json' --post-data='{\"jsonrpc\":\"2.0\",\"method\":\"%s\",\"params\":[],\"id\":1}' http://localhost:8545", method),
 	)
@@ -243,19 +342,19 @@ func (d *Devnet) callBatcherRPC(service, method string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to call %s (%w): %s", method, err, buf.String())
 	}
-	log.Info("RPC call successful", "service", service, "method", method, "response", buf.String())
+	log.Info("RPC call successful", "service", name, "method", method, "response", buf.String())
 	return nil
 }
 
 // StartBatcherSubmitting starts batch submission on a running batcher service
-func (d *Devnet) StartBatcherSubmitting(service string) error {
-	log.Info("starting batch submission", "service", service)
+func (d *Devnet) StartBatcherSubmitting(service Service) error {
+	log.Info("starting batch submission", "service", service.Name(d.profile))
 	return d.callBatcherRPC(service, "admin_startBatcher")
 }
 
 // StopBatcherSubmitting stops batch submission on a running batcher service
-func (d *Devnet) StopBatcherSubmitting(service string) error {
-	log.Info("stopping batch submission", "service", service)
+func (d *Devnet) StopBatcherSubmitting(service Service) error {
+	log.Info("stopping batch submission", "service", service.Name(d.profile))
 	return d.callBatcherRPC(service, "admin_stopBatcher")
 }
 
@@ -409,10 +508,10 @@ func (d *Devnet) SubmitSimpleL2Burn() (*BurnReceipt, error) {
 		return nil, fmt.Errorf("getting initial burn address balance: %w", err)
 	}
 
-	tx := env.L2TxWithOptions(
-		env.L2TxWithAmount(receipt.BurnAmount),
-		env.L2TxWithToAddress(&receipt.BurnAddress),
-		env.L2TxWithVerifyOnClients(d.L2Verif),
+	tx := environment.L2TxWithOptions(
+		environment.L2TxWithAmount(receipt.BurnAmount),
+		environment.L2TxWithToAddress(&receipt.BurnAddress),
+		environment.L2TxWithVerifyOnClients(d.L2Verif),
 	)
 	if receipt.Receipt, err = d.SubmitL2Tx(tx); err != nil {
 		return nil, err
@@ -464,7 +563,7 @@ func (d *Devnet) SleepRecoveryDuration() {
 }
 
 func (d *Devnet) Down() error {
-
+	// Close RPC clients first so no new requests are sent during shutdown.
 	if d.L1 != nil {
 		d.L1.Close()
 	}
@@ -481,42 +580,54 @@ func (d *Devnet) Down() error {
 		d.L2VerifRollup.Close()
 	}
 
-	// Use timeout flag for faster Docker shutdown
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "down", "-v", "--remove-orphans", "--timeout", "10",
-	)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to shut down docker: %w", err)
-	}
+	// Everything below is ephemeral test infrastructure — kill it all
+	// as fast as possible.  We use --timeout 1 so Docker sends SIGTERM
+	// then SIGKILL after just 1 second, and `docker rm -f` (SIGKILL
+	// immediately) for any leftover TEE/enclave containers.  All three
+	// cleanup paths run in parallel.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
 
-	outBatcher, _ := exec.Command("docker", "ps", "-q", "--filter", "ancestor=op-batcher-tee:espresso").Output()
-	batcherContainers := strings.Fields(string(outBatcher))
-	if len(batcherContainers) > 0 {
-		cmd = exec.Command("docker", append([]string{"stop"}, batcherContainers...)...)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to stop the batcher container: %w", err)
+	// 1. docker compose down (kills all compose-managed containers)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := d.composeCommand("down", "-v", "--remove-orphans", "--timeout", "1").Run(); err != nil {
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("docker compose down: %w", err))
+			mu.Unlock()
 		}
-		cmd = exec.Command("docker", append([]string{"rm"}, batcherContainers...)...)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to remove the batcher container: %w", err)
-		}
-	}
+	}()
 
-	outEnclave, _ := exec.Command("docker", "ps", "-aq", "--filter", "name=batcher-enclaver-").Output()
-	enclaveContainers := strings.Fields(string(outEnclave))
-	if len(enclaveContainers) > 0 {
-		cmd = exec.Command("docker", append([]string{"stop"}, enclaveContainers...)...)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to stop the enclave container: %w", err)
+	// 2. Force-kill any batcher-tee containers (started by compose but
+	//    may linger because of the enclave subprocess).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		out, _ := exec.Command("docker", "ps", "-aq", "--filter", "ancestor=op-batcher-tee:espresso").Output()
+		if ids := strings.Fields(string(out)); len(ids) > 0 {
+			_ = exec.Command("docker", append([]string{"rm", "-f"}, ids...)...).Run()
 		}
-		cmd = exec.Command("docker", append([]string{"rm"}, enclaveContainers...)...)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to remove the enclave container: %w", err)
-		}
-	}
+	}()
 
-	return nil
+	// 3. Force-kill any enclave runner containers (spawned inside
+	//    batcher-tee via Docker socket, not managed by compose).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		out, _ := exec.Command("docker", "ps", "-aq", "--filter", "name=batcher-enclaver-").Output()
+		if ids := strings.Fields(string(out)); len(ids) > 0 {
+			_ = exec.Command("docker", append([]string{"rm", "-f"}, ids...)...).Run()
+		}
+		// Terminate Nitro Enclave VMs directly (instant, idempotent).
+		if d.profile == TEE {
+			_ = exec.Command("nitro-cli", "terminate-enclave", "--all").Run()
+		}
+	}()
+
+	wg.Wait()
+	return errors.Join(errs...)
 }
 
 type TaggedWriter struct {
@@ -712,12 +823,9 @@ func (d *Devnet) OpChallengerOutput(opts ...string) (string, error) {
 }
 
 func (d *Devnet) opChallengerCmd(opts ...string) *exec.Cmd {
-	opts = append([]string{"compose", "exec", "op-challenger", "entrypoint.sh", "op-challenger"}, opts...)
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker",
-		opts...,
-	)
+	name := OpChallenger.Name(d.profile)
+	args := append([]string{"exec", name, "entrypoint.sh", "op-challenger"}, opts...)
+	cmd := d.composeCommand(args...)
 	if testing.Verbose() {
 		cmd.Stdout = NewTaggedWriter("op-challenger-cmd", os.Stdout)
 		cmd.Stderr = NewTaggedWriter("op-challenger-cmd", os.Stderr)
@@ -727,13 +835,11 @@ func (d *Devnet) opChallengerCmd(opts ...string) *exec.Cmd {
 }
 
 // Get the host port mapped to `privatePort` for the given Docker service.
-func (d *Devnet) hostPort(service string, privatePort uint16) (uint16, error) {
+func (d *Devnet) hostPort(service Service, privatePort uint16) (uint16, error) {
+	name := service.Name(d.profile)
 	buf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
-	cmd := exec.CommandContext(
-		d.ctx,
-		"docker", "compose", "port", service, fmt.Sprint(privatePort),
-	)
+	cmd := d.composeCommand("port", name, fmt.Sprint(privatePort))
 	cmd.Stdout = buf
 	cmd.Stderr = errBuf
 
@@ -754,26 +860,28 @@ func (d *Devnet) hostPort(service string, privatePort uint16) (uint16, error) {
 }
 
 // Open an Ethereum RPC client for a Docker service running an RPC server on the given port.
-func (d *Devnet) serviceClient(service string, port uint16) (*ethclient.Client, error) {
+func (d *Devnet) serviceClient(service Service, port uint16) (*ethclient.Client, error) {
+	name := service.Name(d.profile)
 	port, err := d.hostPort(service, port)
 	if err != nil {
-		return nil, fmt.Errorf("could not get %s port: %w", service, err)
+		return nil, fmt.Errorf("could not get %s port: %w", name, err)
 	}
 	client, err := ethclient.DialContext(d.ctx, fmt.Sprintf("http://127.0.0.1:%d", port))
 	if err != nil {
-		return nil, fmt.Errorf("could not open %s RPC client: %w", service, err)
+		return nil, fmt.Errorf("could not open %s RPC client: %w", name, err)
 	}
 	return client, nil
 }
 
-func (d *Devnet) rollupClient(service string, port uint16) (*sources.RollupClient, error) {
+func (d *Devnet) rollupClient(service Service, port uint16) (*sources.RollupClient, error) {
+	name := service.Name(d.profile)
 	port, err := d.hostPort(service, port)
 	if err != nil {
-		return nil, fmt.Errorf("could not get %s port: %w", service, err)
+		return nil, fmt.Errorf("could not get %s port: %w", name, err)
 	}
 	rpc, err := opclient.NewRPC(d.ctx, log.Root(), fmt.Sprintf("http://127.0.0.1:%d", port), opclient.WithDialAttempts(10))
 	if err != nil {
-		return nil, fmt.Errorf("could not open %s RPC client: %w", service, err)
+		return nil, fmt.Errorf("could not open %s RPC client: %w", name, err)
 	}
 
 	client := sources.NewRollupClient(rpc)

--- a/espresso/devnet-tests/forced_transaction_test.go
+++ b/espresso/devnet-tests/forced_transaction_test.go
@@ -26,11 +26,15 @@ func TestForcedTransaction(t *testing.T) {
 	defer cancel()
 
 	// Launch docker compose devnet
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	l2Verif := d.L2Verif
 	l1Client := d.L1
@@ -53,7 +57,7 @@ func TestForcedTransaction(t *testing.T) {
 	// Stop the sequencer to force inclusion via L1 deposits
 	// This is required to test the forced transaction mechanism
 	t.Log("Stopping sequencer to test forced inclusion...")
-	err = d.ServiceDown("op-node-sequencer")
+	err = d.ServiceDown(OpNodeSequencer)
 	require.NoError(t, err, "Failed to stop sequencer")
 
 	portal, err := bindings.NewOptimismPortal(optimismPortalAddr, l1Client)

--- a/espresso/devnet-tests/forced_transaction_test.go
+++ b/espresso/devnet-tests/forced_transaction_test.go
@@ -20,76 +20,76 @@ const WAIT_FORCED_TXN_TIME = 25 * time.Second
 // ForcedTransaction attempts to verify that the forced transaction mechanism works for the
 // current Docker Compose devnet
 func TestForcedTransaction(t *testing.T) {
-	// Set up the test timeout condition.
-	// Extended timeout to accommodate slower processing in test environments
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer cancel()
-
-	// Launch docker compose devnet
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		// Set up the test timeout condition.
+		// Extended timeout to accommodate slower processing in test environments
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cancel()
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+		// Launch docker compose devnet
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	l2Verif := d.L2Verif
-	l1Client := d.L1
+		l2Verif := d.L2Verif
+		l1Client := d.L1
 
-	// Alice address
-	aliceAddress := crypto.PubkeyToAddress(d.secrets.Alice.PublicKey)
+		// Alice address
+		aliceAddress := crypto.PubkeyToAddress(d.secrets.Alice.PublicKey)
 
-	// Initial L2 balance
-	initialBalance, err := l2Verif.BalanceAt(ctx, aliceAddress, nil)
-	require.NoError(t, err, "Failed to get initial balance")
-	require.True(t, initialBalance.Cmp(big.NewInt(0)) > 0, "Alice should have positive L2 balance")
-	t.Logf("Alice initial L2 balance: %s", initialBalance.String())
+		// Initial L2 balance
+		initialBalance, err := l2Verif.BalanceAt(ctx, aliceAddress, nil)
+		require.NoError(t, err, "Failed to get initial balance")
+		require.True(t, initialBalance.Cmp(big.NewInt(0)) > 0, "Alice should have positive L2 balance")
+		t.Logf("Alice initial L2 balance: %s", initialBalance.String())
 
-	// Get OptimismPortal address from SystemConfig BEFORE stopping the sequencer
-	systemConfig, _, err := d.SystemConfig(ctx)
-	require.NoError(t, err, "Failed to get systemConfig")
-	optimismPortalAddr, err := systemConfig.OptimismPortal(&bind.CallOpts{})
-	require.NoError(t, err, "Failed to get optimismPortalAddr")
+		// Get OptimismPortal address from SystemConfig BEFORE stopping the sequencer
+		systemConfig, _, err := d.SystemConfig(ctx)
+		require.NoError(t, err, "Failed to get systemConfig")
+		optimismPortalAddr, err := systemConfig.OptimismPortal(&bind.CallOpts{})
+		require.NoError(t, err, "Failed to get optimismPortalAddr")
 
-	// Stop the sequencer to force inclusion via L1 deposits
-	// This is required to test the forced transaction mechanism
-	t.Log("Stopping sequencer to test forced inclusion...")
-	err = d.ServiceDown(OpNodeSequencer)
-	require.NoError(t, err, "Failed to stop sequencer")
+		// Stop the sequencer to force inclusion via L1 deposits
+		// This is required to test the forced transaction mechanism
+		t.Log("Stopping sequencer to test forced inclusion...")
+		err = d.ServiceDown(OpNodeSequencer)
+		require.NoError(t, err, "Failed to stop sequencer")
 
-	portal, err := bindings.NewOptimismPortal(optimismPortalAddr, l1Client)
-	require.NoError(t, err, "Failed to create Optimism portal")
+		portal, err := bindings.NewOptimismPortal(optimismPortalAddr, l1Client)
+		require.NoError(t, err, "Failed to create Optimism portal")
 
-	// L1 signer
-	l1ChainID, err := l1Client.ChainID(ctx)
-	require.NoError(t, err, "Failed to get l1ChainID")
+		// L1 signer
+		l1ChainID, err := l1Client.ChainID(ctx)
+		require.NoError(t, err, "Failed to get l1ChainID")
 
-	opts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Alice, l1ChainID)
-	require.NoError(t, err, "Failed to create withdrawal transaction options")
+		opts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Alice, l1ChainID)
+		require.NoError(t, err, "Failed to create withdrawal transaction options")
 
-	withdrawalAmount := new(big.Int).SetUint64(1000)
-	// Don't set opts.Value - we want to use Alice's existing L2 balance, not mint new ETH
-	opts.GasLimit = 500000 // Set explicit gas limit to avoid gas estimation issues in ResourceMetering
+		withdrawalAmount := new(big.Int).SetUint64(1000)
+		// Don't set opts.Value - we want to use Alice's existing L2 balance, not mint new ETH
+		opts.GasLimit = 500000 // Set explicit gas limit to avoid gas estimation issues in ResourceMetering
 
-	// Forced transaction via L1 deposit
-	tx, err := portal.DepositTransaction(
-		opts,
-		common.HexToAddress(predeploys.L2ToL1MessagePasser),
-		withdrawalAmount,
-		uint64(100_000), // L2 gas limit - reduced since we just need the deposit to go through
-		false,
-		nil,
-	)
-	require.NoError(t, err, "Failed to create transaction")
-	t.Logf("Deposit transaction submitted: %s", tx.Hash().Hex())
-	receipt, err := bind.WaitMined(ctx, l1Client, tx)
-	require.NoError(t, err, "Transaction not minted")
+		// Forced transaction via L1 deposit
+		tx, err := portal.DepositTransaction(
+			opts,
+			common.HexToAddress(predeploys.L2ToL1MessagePasser),
+			withdrawalAmount,
+			uint64(100_000), // L2 gas limit - reduced since we just need the deposit to go through
+			false,
+			nil,
+		)
+		require.NoError(t, err, "Failed to create transaction")
+		t.Logf("Deposit transaction submitted: %s", tx.Hash().Hex())
+		receipt, err := bind.WaitMined(ctx, l1Client, tx)
+		require.NoError(t, err, "Transaction not minted")
 
-	// Note: we only check the transaction goes through, we don't wait for the sequencer window to expire and the deposit to be processed by the verifier.
-	// This is because it would take too long to test on the local devnet as reducing the sequencer window size breaks the other tests.
-	t.Logf("Deposit transaction mined in block %d", receipt.BlockNumber.Uint64())
-
+		// Note: we only check the transaction goes through, we don't wait for the sequencer window to expire and the deposit to be processed by the verifier.
+		// This is because it would take too long to test on the local devnet as reducing the sequencer window size breaks the other tests.
+		t.Logf("Deposit transaction mined in block %d", receipt.BlockNumber.Uint64())
+	})
 }

--- a/espresso/devnet-tests/key_rotation_test.go
+++ b/espresso/devnet-tests/key_rotation_test.go
@@ -16,111 +16,112 @@ import (
 )
 
 func TestChangeBatchAuthenticatorOwner(t *testing.T) {
-	// Load environment variables from .env file
-	err := LoadDevnetEnv()
-	require.NoError(t, err, "Failed to load .env file")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		// Load environment variables from .env file
+		err := LoadDevnetEnv()
+		require.NoError(t, err, "Failed to load .env file")
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
 
-	// Send a transaction just to check that everything has started up ok.
-	require.NoError(t, d.RunSimpleL2Burn())
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	config, err := d.RollupConfig(ctx)
-	require.NoError(t, err)
+		// Send a transaction just to check that everything has started up ok.
+		require.NoError(t, d.RunSimpleL2Burn())
 
-	batchAuthenticator, err := bindings.NewBatchAuthenticator(config.BatchAuthenticatorAddress, d.L1)
-	require.NoError(t, err)
+		config, err := d.RollupConfig(ctx)
+		require.NoError(t, err)
 
-	// Get L1 chain ID for transaction signing
-	l1ChainID, err := d.L1.ChainID(ctx)
-	require.NoError(t, err)
+		batchAuthenticator, err := bindings.NewBatchAuthenticator(config.BatchAuthenticatorAddress, d.L1)
+		require.NoError(t, err)
 
-	// Check current owner first
-	currentOwner, err := batchAuthenticator.Owner(&bind.CallOpts{})
-	require.NoError(t, err)
+		// Get L1 chain ID for transaction signing
+		l1ChainID, err := d.L1.ChainID(ctx)
+		require.NoError(t, err)
 
-	// Check that the new owner is different from the current one
-	bobAddress := d.secrets.Addresses().Bob
-	require.NotEqual(t, currentOwner, bobAddress)
+		// Check current owner first
+		currentOwner, err := batchAuthenticator.Owner(&bind.CallOpts{})
+		require.NoError(t, err)
 
-	// Get the ProxyAdmin address from the BatchAuthenticator proxy
-	proxyContract, err := e2ebindings.NewProxy(config.BatchAuthenticatorAddress, d.L1)
-	require.NoError(t, err)
+		// Check that the new owner is different from the current one
+		bobAddress := d.secrets.Addresses().Bob
+		require.NotEqual(t, currentOwner, bobAddress)
 
-	var result []interface{}
-	proxyRaw := &e2ebindings.ProxyRaw{Contract: proxyContract}
-	err = proxyRaw.Call(&bind.CallOpts{}, &result, "admin")
-	require.NoError(t, err)
-	require.Len(t, result, 1, "admin() should return one value")
-	proxyAdminAddress := result[0].(common.Address)
-	require.NotEqual(t, proxyAdminAddress, common.Address{}, "ProxyAdmin address should not be zero")
+		// Get the ProxyAdmin address from the BatchAuthenticator proxy
+		proxyContract, err := e2ebindings.NewProxy(config.BatchAuthenticatorAddress, d.L1)
+		require.NoError(t, err)
 
-	// Get ProxyAdmin contract binding
-	proxyAdmin, err := e2ebindings.NewProxyAdmin(proxyAdminAddress, d.L1)
-	require.NoError(t, err)
+		var result []interface{}
+		proxyRaw := &e2ebindings.ProxyRaw{Contract: proxyContract}
+		err = proxyRaw.Call(&bind.CallOpts{}, &result, "admin")
+		require.NoError(t, err)
+		require.Len(t, result, 1, "admin() should return one value")
+		proxyAdminAddress := result[0].(common.Address)
+		require.NotEqual(t, proxyAdminAddress, common.Address{}, "ProxyAdmin address should not be zero")
 
-	// Verify current owner matches initially (they're set to the same address during deployment)
-	proxyAdminOwner, err := proxyAdmin.Owner(&bind.CallOpts{})
-	require.NoError(t, err)
-	require.Equal(t, currentOwner, proxyAdminOwner, "BatchAuthenticator owner should initially match ProxyAdmin owner")
+		// Get ProxyAdmin contract binding
+		proxyAdmin, err := e2ebindings.NewProxyAdmin(proxyAdminAddress, d.L1)
+		require.NoError(t, err)
 
-	// Use batch authenticator owner key to sign the transaction
-	batchAuthenticatorPrivateKeyHex := os.Getenv("BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY")
-	require.NotEmpty(t, batchAuthenticatorPrivateKeyHex, "BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY must be set")
-	t.Logf("Using BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY from environment: %s...", batchAuthenticatorPrivateKeyHex[:10])
+		// Verify current owner matches initially (they're set to the same address during deployment)
+		proxyAdminOwner, err := proxyAdmin.Owner(&bind.CallOpts{})
+		require.NoError(t, err)
+		require.Equal(t, currentOwner, proxyAdminOwner, "BatchAuthenticator owner should initially match ProxyAdmin owner")
 
-	batchAuthenticatorKey, err := crypto.HexToECDSA(strings.TrimPrefix(batchAuthenticatorPrivateKeyHex, "0x"))
-	require.NoError(t, err)
+		// Use batch authenticator owner key to sign the transaction
+		batchAuthenticatorPrivateKeyHex := os.Getenv("BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY")
+		require.NotEmpty(t, batchAuthenticatorPrivateKeyHex, "BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY must be set")
+		t.Logf("Using BATCH_AUTHENTICATOR_OWNER_PRIVATE_KEY from environment: %s...", batchAuthenticatorPrivateKeyHex[:10])
 
-	batchAuthenticatorOwnerOpts, err := bind.NewKeyedTransactorWithChainID(batchAuthenticatorKey, l1ChainID)
-	require.NoError(t, err)
+		batchAuthenticatorKey, err := crypto.HexToECDSA(strings.TrimPrefix(batchAuthenticatorPrivateKeyHex, "0x"))
+		require.NoError(t, err)
 
-	// Transfer ownership of both ProxyAdmin and BatchAuthenticator
-	// Note: BatchAuthenticator and ProxyAdmin have independent ownership since the migration
-	// to OwnableWithGuardiansUpgradeable, so we need to transfer both.
+		batchAuthenticatorOwnerOpts, err := bind.NewKeyedTransactorWithChainID(batchAuthenticatorKey, l1ChainID)
+		require.NoError(t, err)
 
-	// 1. Transfer ProxyAdmin ownership
-	tx, err := proxyAdmin.TransferOwnership(batchAuthenticatorOwnerOpts, bobAddress)
-	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(ctx, d.L1, tx.Hash())
-	require.NoError(t, err)
+		// Transfer ownership of both ProxyAdmin and BatchAuthenticator
+		// Note: BatchAuthenticator and ProxyAdmin have independent ownership since the migration
+		// to OwnableWithGuardiansUpgradeable, so we need to transfer both.
 
-	// 2. Transfer BatchAuthenticator ownership (2-step process with Ownable2StepUpgradeable)
-	// Step 2a: Current owner initiates transfer
-	tx, err = batchAuthenticator.TransferOwnership(batchAuthenticatorOwnerOpts, bobAddress)
-	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(ctx, d.L1, tx.Hash())
-	require.NoError(t, err)
+		// 1. Transfer ProxyAdmin ownership
+		tx, err := proxyAdmin.TransferOwnership(batchAuthenticatorOwnerOpts, bobAddress)
+		require.NoError(t, err)
+		_, err = wait.ForReceiptOK(ctx, d.L1, tx.Hash())
+		require.NoError(t, err)
 
-	// Step 2b: New owner (Bob) accepts ownership
-	bobOpts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Bob, l1ChainID)
-	require.NoError(t, err)
-	tx, err = batchAuthenticator.AcceptOwnership(bobOpts)
-	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(ctx, d.L1, tx.Hash())
-	require.NoError(t, err)
+		// 2. Transfer BatchAuthenticator ownership (2-step process with Ownable2StepUpgradeable)
+		// Step 2a: Current owner initiates transfer
+		tx, err = batchAuthenticator.TransferOwnership(batchAuthenticatorOwnerOpts, bobAddress)
+		require.NoError(t, err)
+		_, err = wait.ForReceiptOK(ctx, d.L1, tx.Hash())
+		require.NoError(t, err)
 
-	// Verify ProxyAdmin owner has been changed
-	newProxyAdminOwner, err := proxyAdmin.Owner(&bind.CallOpts{})
-	require.NoError(t, err)
-	require.Equal(t, bobAddress, newProxyAdminOwner, "ProxyAdmin owner should be updated to Bob")
+		// Step 2b: New owner (Bob) accepts ownership
+		bobOpts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Bob, l1ChainID)
+		require.NoError(t, err)
+		tx, err = batchAuthenticator.AcceptOwnership(bobOpts)
+		require.NoError(t, err)
+		_, err = wait.ForReceiptOK(ctx, d.L1, tx.Hash())
+		require.NoError(t, err)
 
-	// Verify BatchAuthenticator owner has been changed
-	newOwner, err := batchAuthenticator.Owner(&bind.CallOpts{})
-	require.NoError(t, err)
-	require.Equal(t, bobAddress, newOwner, "BatchAuthenticator owner should be updated to Bob")
+		// Verify ProxyAdmin owner has been changed
+		newProxyAdminOwner, err := proxyAdmin.Owner(&bind.CallOpts{})
+		require.NoError(t, err)
+		require.Equal(t, bobAddress, newProxyAdminOwner, "ProxyAdmin owner should be updated to Bob")
 
-	// Check that everything still functions
-	require.NoError(t, d.RunSimpleL2Burn())
+		// Verify BatchAuthenticator owner has been changed
+		newOwner, err := batchAuthenticator.Owner(&bind.CallOpts{})
+		require.NoError(t, err)
+		require.Equal(t, bobAddress, newOwner, "BatchAuthenticator owner should be updated to Bob")
+
+		// Check that everything still functions
+		require.NoError(t, d.RunSimpleL2Burn())
+	})
 }

--- a/espresso/devnet-tests/key_rotation_test.go
+++ b/espresso/devnet-tests/key_rotation_test.go
@@ -23,12 +23,15 @@ func TestChangeBatchAuthenticatorOwner(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d := NewDevnet(ctx, t)
+	profile := ProfileFromEnv(t)
 
-	require.NoError(t, d.Up(FALLBACK))
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	// Send a transaction just to check that everything has started up ok.
 	require.NoError(t, d.RunSimpleL2Burn())

--- a/espresso/devnet-tests/smoke_test.go
+++ b/espresso/devnet-tests/smoke_test.go
@@ -9,19 +9,20 @@ import (
 )
 
 func TestSmoke(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
-	defer cancel()
-
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		defer cancel()
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() {
+			require.NoError(t, d.Down())
+		}()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	// Send a transaction just to check that everything has started up ok.
-	require.NoError(t, d.RunSimpleL2Burn())
+		// Send a transaction just to check that everything has started up ok.
+		require.NoError(t, d.RunSimpleL2Burn())
+	})
 }

--- a/espresso/devnet-tests/smoke_test.go
+++ b/espresso/devnet-tests/smoke_test.go
@@ -8,29 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSmokeWithFallback(t *testing.T) {
+func TestSmoke(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() {
 		require.NoError(t, d.Down())
 	}()
 
-	// Send a transaction just to check that everything has started up ok.
-	require.NoError(t, d.RunSimpleL2Burn())
-}
-
-func TestSmokeWithEspresso(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
-	defer cancel()
-
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(ESPRESSO))
-	defer func() {
-		require.NoError(t, d.Down())
-	}()
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	// Send a transaction just to check that everything has started up ok.
 	require.NoError(t, d.RunSimpleL2Burn())

--- a/espresso/devnet-tests/withdraw_test.go
+++ b/espresso/devnet-tests/withdraw_test.go
@@ -33,9 +33,13 @@ func TestWithdrawal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d := NewDevnet(ctx, t)
-	require.NoError(t, d.Up(FALLBACK))
+	profile := ProfileFromEnv(t)
+
+	d := NewDevnet(ctx, t, profile)
+	require.NoError(t, d.Up())
 	defer func() { require.NoError(t, d.Down()) }()
+
+	require.NoError(t, d.WaitForBatcher(ctx, t))
 
 	alice := crypto.PubkeyToAddress(d.secrets.Alice.PublicKey)
 	callOpts := &bind.CallOpts{Context: ctx}

--- a/espresso/devnet-tests/withdraw_test.go
+++ b/espresso/devnet-tests/withdraw_test.go
@@ -30,253 +30,254 @@ func l2BlockFromExtraData(extraData []byte) (*big.Int, error) {
 }
 
 func TestWithdrawal(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	profile := ProfileFromEnv(t)
+	t.Run(string(profile), func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	d := NewDevnet(ctx, t, profile)
-	require.NoError(t, d.Up())
-	defer func() { require.NoError(t, d.Down()) }()
+		d := NewDevnet(ctx, t, profile)
+		require.NoError(t, d.Up())
+		defer func() { require.NoError(t, d.Down()) }()
 
-	require.NoError(t, d.WaitForBatcher(ctx, t))
+		require.NoError(t, d.WaitForBatcher(ctx))
 
-	alice := crypto.PubkeyToAddress(d.secrets.Alice.PublicKey)
-	callOpts := &bind.CallOpts{Context: ctx}
+		alice := crypto.PubkeyToAddress(d.secrets.Alice.PublicKey)
+		callOpts := &bind.CallOpts{Context: ctx}
 
-	l1ChainID, err := d.L1.ChainID(ctx)
-	require.NoError(t, err, "failed to get L1 chain ID")
+		l1ChainID, err := d.L1.ChainID(ctx)
+		require.NoError(t, err, "failed to get L1 chain ID")
 
-	l1Transactor := func() *bind.TransactOpts {
-		opts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Alice, l1ChainID)
-		require.NoError(t, err, "failed to create L1 transactor")
-		return opts
-	}
-
-	// Get contract addresses
-	systemConfig, _, err := d.SystemConfig(ctx)
-	require.NoError(t, err)
-
-	factoryAddr, err := systemConfig.DisputeGameFactory(callOpts)
-	require.NoError(t, err, "failed to get DisputeGameFactory address")
-
-	portalAddr, err := systemConfig.OptimismPortal(callOpts)
-	require.NoError(t, err, "failed to get OptimismPortal address")
-
-	factory, err := nodebindings.NewDisputeGameFactoryCaller(factoryAddr, d.L1)
-	require.NoError(t, err, "failed to bind DisputeGameFactory")
-
-	portal2, err := nodepreview.NewOptimismPortal2(portalAddr, d.L1)
-	require.NoError(t, err, "failed to bind OptimismPortal2")
-
-	portal2Caller, err := nodepreview.NewOptimismPortal2Caller(portalAddr, d.L1)
-	require.NoError(t, err, "failed to bind OptimismPortal2Caller")
-
-	gameType, err := portal2Caller.RespectedGameType(callOpts)
-	require.NoError(t, err, "failed to get respected game type")
-
-	// Step 1: Wait for proposer to start (just need 1 game)
-	t.Log("Waiting for proposer to create first game...")
-	require.Eventually(t, func() bool {
-		count, err := factory.GameCount(callOpts)
-		if err != nil {
-			t.Logf("Error getting game count: %v", err)
-			return false
+		l1Transactor := func() *bind.TransactOpts {
+			opts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Alice, l1ChainID)
+			require.NoError(t, err, "failed to create L1 transactor")
+			return opts
 		}
-		if count != nil && count.Cmp(common.Big0) > 0 {
-			t.Logf("Proposer started: %d games", count)
-			return true
-		}
-		return false
-	}, 3*time.Minute, 2*time.Second, "proposer didn't start")
 
-	// Step 2: Initiate withdrawal
-	t.Log("Initiating withdrawal on L2...")
-	withdrawalAmount := big.NewInt(1e18) // 1 ETH
+		// Get contract addresses
+		systemConfig, _, err := d.SystemConfig(ctx)
+		require.NoError(t, err)
 
-	// Deposit ETH to L1 bridge to fund withdrawals
-	t.Log("Depositing ETH to L1 bridge...")
-	rollupConfig, err := d.RollupConfig(ctx)
-	require.NoError(t, err, "failed to get rollup config")
+		factoryAddr, err := systemConfig.DisputeGameFactory(callOpts)
+		require.NoError(t, err, "failed to get DisputeGameFactory address")
 
-	depositContract, err := bindings.NewOptimismPortal(rollupConfig.DepositContractAddress, d.L1)
-	require.NoError(t, err, "failed to bind deposit contract")
+		portalAddr, err := systemConfig.OptimismPortal(callOpts)
+		require.NoError(t, err, "failed to get OptimismPortal address")
 
-	depositOpts := l1Transactor()
-	depositOpts.Value = new(big.Int).Mul(withdrawalAmount, big.NewInt(2))
-	depositOpts.GasLimit = 500000
-	depositTx, err := depositContract.DepositTransaction(depositOpts, common.Address{}, depositOpts.Value, 21000, false, nil)
-	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(ctx, d.L1, depositTx.Hash())
-	require.NoError(t, err)
-	t.Log("Deposit complete!")
+		factory, err := nodebindings.NewDisputeGameFactoryCaller(factoryAddr, d.L1)
+		require.NoError(t, err, "failed to bind DisputeGameFactory")
 
-	l2MessagePasser, err := bindings.NewL2ToL1MessagePasser(
-		common.HexToAddress("0x4200000000000000000000000000000000000016"), d.L2Seq)
-	require.NoError(t, err, "failed to bind L2ToL1MessagePasser")
+		portal2, err := nodepreview.NewOptimismPortal2(portalAddr, d.L1)
+		require.NoError(t, err, "failed to bind OptimismPortal2")
 
-	l2ChainID, err := d.L2Seq.ChainID(ctx)
-	require.NoError(t, err, "failed to get L2 chain ID")
+		portal2Caller, err := nodepreview.NewOptimismPortal2Caller(portalAddr, d.L1)
+		require.NoError(t, err, "failed to bind OptimismPortal2Caller")
 
-	l2Opts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Alice, l2ChainID)
-	require.NoError(t, err, "failed to create L2 transactor")
-	l2Opts.Value = withdrawalAmount
+		gameType, err := portal2Caller.RespectedGameType(callOpts)
+		require.NoError(t, err, "failed to get respected game type")
 
-	withdrawTx, err := l2MessagePasser.InitiateWithdrawal(l2Opts, alice, big.NewInt(21000), nil)
-	require.NoError(t, err)
-	withdrawReceipt, err := wait.ForReceiptOK(ctx, d.L2Verif, withdrawTx.Hash())
-	require.NoError(t, err)
-	t.Logf("Withdrawal initiated at L2 block %d", withdrawReceipt.BlockNumber)
-
-	// Step 3: Wait for a dispute game covering the withdrawal block
-	t.Logf("Waiting for dispute game covering L2 block %d...", withdrawReceipt.BlockNumber)
-	var gameIndex *big.Int
-	var gameProxy common.Address
-	var gameL2Block *big.Int
-	require.Eventually(t, func() bool {
-		count, err := factory.GameCount(callOpts)
-		if err != nil || count == nil || count.Cmp(common.Big0) == 0 {
-			return false
-		}
-		games, err := factory.FindLatestGames(callOpts, gameType, new(big.Int).Sub(count, common.Big1), big.NewInt(1))
-		if err != nil || len(games) == 0 {
-			return false
-		}
-		var parseErr error
-		gameL2Block, parseErr = l2BlockFromExtraData(games[0].ExtraData)
-		if parseErr != nil {
-			t.Logf("Error parsing extraData: %v", parseErr)
-			return false
-		}
-		t.Logf("Latest game: index=%d, L2Block=%d (need >= %d)", games[0].Index, gameL2Block, withdrawReceipt.BlockNumber)
-		if gameL2Block.Cmp(withdrawReceipt.BlockNumber) >= 0 {
-			gameIndex = games[0].Index
-			info, err := factory.GameAtIndex(callOpts, games[0].Index)
+		// Step 1: Wait for proposer to start (just need 1 game)
+		t.Log("Waiting for proposer to create first game...")
+		require.Eventually(t, func() bool {
+			count, err := factory.GameCount(callOpts)
 			if err != nil {
-				t.Logf("Error getting game info: %v", err)
+				t.Logf("Error getting game count: %v", err)
 				return false
 			}
-			gameProxy = info.Proxy
-			return true
-		}
-		return false
-	}, 10*time.Minute, 5*time.Second, "no game covering withdrawal block")
-
-	// Step 4: Prove the dispute game (mock verifier accepts empty proof)
-	t.Log("Proving dispute game...")
-	disputeGame, err := espressobindings.NewOPSuccinctFaultDisputeGame(gameProxy, d.L1)
-	require.NoError(t, err)
-
-	proveTx, err := disputeGame.Prove(l1Transactor(), []byte{})
-	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(ctx, d.L1, proveTx.Hash())
-	require.NoError(t, err)
-	t.Log("Dispute game proven!")
-
-	// Step 5: Prove withdrawal transaction
-	t.Log("Proving withdrawal transaction...")
-	l2Header, err := d.L2Seq.HeaderByNumber(ctx, gameL2Block)
-	require.NoError(t, err, "failed to get L2 header")
-
-	proofCl := gethclient.New(d.L2Seq.Client())
-	params, err := withdrawals.ProveWithdrawalParametersForBlock(ctx, proofCl, d.L2Seq, withdrawTx.Hash(), l2Header, gameIndex)
-	require.NoError(t, err)
-
-	withdrawalTxStruct := nodepreview.TypesWithdrawalTransaction{
-		Nonce: params.Nonce, Sender: params.Sender, Target: params.Target,
-		Value: params.Value, GasLimit: params.GasLimit, Data: params.Data,
-	}
-	outputProof := nodepreview.TypesOutputRootProof{
-		Version:                  params.OutputRootProof.Version,
-		StateRoot:                params.OutputRootProof.StateRoot,
-		MessagePasserStorageRoot: params.OutputRootProof.MessagePasserStorageRoot,
-		LatestBlockhash:          params.OutputRootProof.LatestBlockhash,
-	}
-
-	proveWithdrawOpts := l1Transactor()
-	proveWithdrawOpts.GasLimit = 500000
-	proveWithdrawTx, err := portal2.ProveWithdrawalTransaction(proveWithdrawOpts, withdrawalTxStruct, gameIndex, outputProof, params.WithdrawalProof)
-	require.NoError(t, err)
-	proveReceipt, err := wait.ForReceiptOK(ctx, d.L1, proveWithdrawTx.Hash())
-	require.NoError(t, err)
-	t.Log("Withdrawal proven!")
-
-	// Step 6: Wait for proof maturity + game resolution
-	t.Log("Waiting for proof maturity and game resolution...")
-
-	maturityDelay, err := portal2Caller.ProofMaturityDelaySeconds(callOpts)
-	require.NoError(t, err, "failed to get proof maturity delay")
-
-	disputeGameFinalityDelay, err := portal2Caller.DisputeGameFinalityDelaySeconds(callOpts)
-	require.NoError(t, err, "failed to get dispute game finality delay")
-
-	// Wait for game to be resolved
-	require.Eventually(t, func() bool {
-		status, err := disputeGame.Status(callOpts)
-		if err != nil {
-			t.Logf("Error getting game status: %v", err)
+			if count != nil && count.Cmp(common.Big0) > 0 {
+				t.Logf("Proposer started: %d games", count)
+				return true
+			}
 			return false
-		}
-		if status != 0 {
-			t.Logf("Game resolved with status: %d", status)
-			return true
-		}
-		// Try manual resolution
-		resolveTx, err := disputeGame.Resolve(l1Transactor())
-		if err != nil {
-			t.Logf("Error calling Resolve (may be expected): %v", err)
+		}, 3*time.Minute, 2*time.Second, "proposer didn't start")
+
+		// Step 2: Initiate withdrawal
+		t.Log("Initiating withdrawal on L2...")
+		withdrawalAmount := big.NewInt(1e18) // 1 ETH
+
+		// Deposit ETH to L1 bridge to fund withdrawals
+		t.Log("Depositing ETH to L1 bridge...")
+		rollupConfig, err := d.RollupConfig(ctx)
+		require.NoError(t, err, "failed to get rollup config")
+
+		depositContract, err := bindings.NewOptimismPortal(rollupConfig.DepositContractAddress, d.L1)
+		require.NoError(t, err, "failed to bind deposit contract")
+
+		depositOpts := l1Transactor()
+		depositOpts.Value = new(big.Int).Mul(withdrawalAmount, big.NewInt(2))
+		depositOpts.GasLimit = 500000
+		depositTx, err := depositContract.DepositTransaction(depositOpts, common.Address{}, depositOpts.Value, 21000, false, nil)
+		require.NoError(t, err)
+		_, err = wait.ForReceiptOK(ctx, d.L1, depositTx.Hash())
+		require.NoError(t, err)
+		t.Log("Deposit complete!")
+
+		l2MessagePasser, err := bindings.NewL2ToL1MessagePasser(
+			common.HexToAddress("0x4200000000000000000000000000000000000016"), d.L2Seq)
+		require.NoError(t, err, "failed to bind L2ToL1MessagePasser")
+
+		l2ChainID, err := d.L2Seq.ChainID(ctx)
+		require.NoError(t, err, "failed to get L2 chain ID")
+
+		l2Opts, err := bind.NewKeyedTransactorWithChainID(d.secrets.Alice, l2ChainID)
+		require.NoError(t, err, "failed to create L2 transactor")
+		l2Opts.Value = withdrawalAmount
+
+		withdrawTx, err := l2MessagePasser.InitiateWithdrawal(l2Opts, alice, big.NewInt(21000), nil)
+		require.NoError(t, err)
+		withdrawReceipt, err := wait.ForReceiptOK(ctx, d.L2Verif, withdrawTx.Hash())
+		require.NoError(t, err)
+		t.Logf("Withdrawal initiated at L2 block %d", withdrawReceipt.BlockNumber)
+
+		// Step 3: Wait for a dispute game covering the withdrawal block
+		t.Logf("Waiting for dispute game covering L2 block %d...", withdrawReceipt.BlockNumber)
+		var gameIndex *big.Int
+		var gameProxy common.Address
+		var gameL2Block *big.Int
+		require.Eventually(t, func() bool {
+			count, err := factory.GameCount(callOpts)
+			if err != nil || count == nil || count.Cmp(common.Big0) == 0 {
+				return false
+			}
+			games, err := factory.FindLatestGames(callOpts, gameType, new(big.Int).Sub(count, common.Big1), big.NewInt(1))
+			if err != nil || len(games) == 0 {
+				return false
+			}
+			var parseErr error
+			gameL2Block, parseErr = l2BlockFromExtraData(games[0].ExtraData)
+			if parseErr != nil {
+				t.Logf("Error parsing extraData: %v", parseErr)
+				return false
+			}
+			t.Logf("Latest game: index=%d, L2Block=%d (need >= %d)", games[0].Index, gameL2Block, withdrawReceipt.BlockNumber)
+			if gameL2Block.Cmp(withdrawReceipt.BlockNumber) >= 0 {
+				gameIndex = games[0].Index
+				info, err := factory.GameAtIndex(callOpts, games[0].Index)
+				if err != nil {
+					t.Logf("Error getting game info: %v", err)
+					return false
+				}
+				gameProxy = info.Proxy
+				return true
+			}
 			return false
+		}, 10*time.Minute, 5*time.Second, "no game covering withdrawal block")
+
+		// Step 4: Prove the dispute game (mock verifier accepts empty proof)
+		t.Log("Proving dispute game...")
+		disputeGame, err := espressobindings.NewOPSuccinctFaultDisputeGame(gameProxy, d.L1)
+		require.NoError(t, err)
+
+		proveTx, err := disputeGame.Prove(l1Transactor(), []byte{})
+		require.NoError(t, err)
+		_, err = wait.ForReceiptOK(ctx, d.L1, proveTx.Hash())
+		require.NoError(t, err)
+		t.Log("Dispute game proven!")
+
+		// Step 5: Prove withdrawal transaction
+		t.Log("Proving withdrawal transaction...")
+		l2Header, err := d.L2Seq.HeaderByNumber(ctx, gameL2Block)
+		require.NoError(t, err, "failed to get L2 header")
+
+		proofCl := gethclient.New(d.L2Seq.Client())
+		params, err := withdrawals.ProveWithdrawalParametersForBlock(ctx, proofCl, d.L2Seq, withdrawTx.Hash(), l2Header, gameIndex)
+		require.NoError(t, err)
+
+		withdrawalTxStruct := nodepreview.TypesWithdrawalTransaction{
+			Nonce: params.Nonce, Sender: params.Sender, Target: params.Target,
+			Value: params.Value, GasLimit: params.GasLimit, Data: params.Data,
 		}
-		_, err = wait.ForReceiptOK(ctx, d.L1, resolveTx.Hash())
-		if err != nil {
-			t.Logf("Resolve tx failed: %v", err)
+		outputProof := nodepreview.TypesOutputRootProof{
+			Version:                  params.OutputRootProof.Version,
+			StateRoot:                params.OutputRootProof.StateRoot,
+			MessagePasserStorageRoot: params.OutputRootProof.MessagePasserStorageRoot,
+			LatestBlockhash:          params.OutputRootProof.LatestBlockhash,
+		}
+
+		proveWithdrawOpts := l1Transactor()
+		proveWithdrawOpts.GasLimit = 500000
+		proveWithdrawTx, err := portal2.ProveWithdrawalTransaction(proveWithdrawOpts, withdrawalTxStruct, gameIndex, outputProof, params.WithdrawalProof)
+		require.NoError(t, err)
+		proveReceipt, err := wait.ForReceiptOK(ctx, d.L1, proveWithdrawTx.Hash())
+		require.NoError(t, err)
+		t.Log("Withdrawal proven!")
+
+		// Step 6: Wait for proof maturity + game resolution
+		t.Log("Waiting for proof maturity and game resolution...")
+
+		maturityDelay, err := portal2Caller.ProofMaturityDelaySeconds(callOpts)
+		require.NoError(t, err, "failed to get proof maturity delay")
+
+		disputeGameFinalityDelay, err := portal2Caller.DisputeGameFinalityDelaySeconds(callOpts)
+		require.NoError(t, err, "failed to get dispute game finality delay")
+
+		// Wait for game to be resolved
+		require.Eventually(t, func() bool {
+			status, err := disputeGame.Status(callOpts)
+			if err != nil {
+				t.Logf("Error getting game status: %v", err)
+				return false
+			}
+			if status != 0 {
+				t.Logf("Game resolved with status: %d", status)
+				return true
+			}
+			// Try manual resolution
+			resolveTx, err := disputeGame.Resolve(l1Transactor())
+			if err != nil {
+				t.Logf("Error calling Resolve (may be expected): %v", err)
+				return false
+			}
+			_, err = wait.ForReceiptOK(ctx, d.L1, resolveTx.Hash())
+			if err != nil {
+				t.Logf("Resolve tx failed: %v", err)
+				return false
+			}
+			return false // Recheck status on next iteration
+		}, 5*time.Minute, 5*time.Second, "game not resolved")
+
+		// Wait for proof maturity + finality delays by polling L1 block time
+		t.Log("Waiting for proof maturity and dispute game finality delays...")
+		proveBlock, err := d.L1.HeaderByNumber(ctx, proveReceipt.BlockNumber)
+		require.NoError(t, err, "failed to get prove block header")
+		targetTime := proveBlock.Time + maturityDelay.Uint64() + disputeGameFinalityDelay.Uint64() + 10
+
+		require.Eventually(t, func() bool {
+			header, err := d.L1.HeaderByNumber(ctx, nil)
+			if err != nil {
+				return false
+			}
+			if header.Time >= targetTime {
+				return true
+			}
+			t.Logf("Waiting for delays: %ds remaining", targetTime-header.Time)
 			return false
-		}
-		return false // Recheck status on next iteration
-	}, 5*time.Minute, 5*time.Second, "game not resolved")
+		}, 3*time.Minute, 2*time.Second, "timeout waiting for delays")
 
-	// Wait for proof maturity + finality delays by polling L1 block time
-	t.Log("Waiting for proof maturity and dispute game finality delays...")
-	proveBlock, err := d.L1.HeaderByNumber(ctx, proveReceipt.BlockNumber)
-	require.NoError(t, err, "failed to get prove block header")
-	targetTime := proveBlock.Time + maturityDelay.Uint64() + disputeGameFinalityDelay.Uint64() + 10
+		// Step 7: Finalize withdrawal
+		t.Log("Finalizing withdrawal...")
+		balanceBefore, err := d.L1.BalanceAt(ctx, alice, nil)
+		require.NoError(t, err, "failed to get balance before finalize")
 
-	require.Eventually(t, func() bool {
-		header, err := d.L1.HeaderByNumber(ctx, nil)
-		if err != nil {
-			return false
-		}
-		if header.Time >= targetTime {
-			return true
-		}
-		t.Logf("Waiting for delays: %ds remaining", targetTime-header.Time)
-		return false
-	}, 3*time.Minute, 2*time.Second, "timeout waiting for delays")
+		finalizeOpts := l1Transactor()
+		finalizeOpts.GasLimit = 300000
+		finalizeTx, err := portal2.FinalizeWithdrawalTransaction(finalizeOpts, withdrawalTxStruct)
+		require.NoError(t, err)
+		finalizeReceipt, err := wait.ForReceiptOK(ctx, d.L1, finalizeTx.Hash())
+		require.NoError(t, err)
 
-	// Step 7: Finalize withdrawal
-	t.Log("Finalizing withdrawal...")
-	balanceBefore, err := d.L1.BalanceAt(ctx, alice, nil)
-	require.NoError(t, err, "failed to get balance before finalize")
+		// Verify balance increased (withdrawal amount minus gas fees)
+		balanceAfter, err := d.L1.BalanceAt(ctx, alice, nil)
+		require.NoError(t, err, "failed to get balance after finalize")
 
-	finalizeOpts := l1Transactor()
-	finalizeOpts.GasLimit = 300000
-	finalizeTx, err := portal2.FinalizeWithdrawalTransaction(finalizeOpts, withdrawalTxStruct)
-	require.NoError(t, err)
-	finalizeReceipt, err := wait.ForReceiptOK(ctx, d.L1, finalizeTx.Hash())
-	require.NoError(t, err)
+		gasCost := new(big.Int).Mul(big.NewInt(int64(finalizeReceipt.GasUsed)), finalizeReceipt.EffectiveGasPrice)
+		balanceChange := new(big.Int).Sub(balanceAfter, balanceBefore)
+		expectedChange := new(big.Int).Sub(withdrawalAmount, gasCost)
 
-	// Verify balance increased (withdrawal amount minus gas fees)
-	balanceAfter, err := d.L1.BalanceAt(ctx, alice, nil)
-	require.NoError(t, err, "failed to get balance after finalize")
+		// Use GreaterOrEqual to account for any minor discrepancies (e.g., rounding)
+		// The balance should increase by at least (withdrawalAmount - gasCost)
+		require.True(t, balanceChange.Cmp(expectedChange) >= 0,
+			"balance didn't increase as expected: got change %s, expected at least %s", balanceChange, expectedChange)
 
-	gasCost := new(big.Int).Mul(big.NewInt(int64(finalizeReceipt.GasUsed)), finalizeReceipt.EffectiveGasPrice)
-	balanceChange := new(big.Int).Sub(balanceAfter, balanceBefore)
-	expectedChange := new(big.Int).Sub(withdrawalAmount, gasCost)
-
-	// Use GreaterOrEqual to account for any minor discrepancies (e.g., rounding)
-	// The balance should increase by at least (withdrawalAmount - gasCost)
-	require.True(t, balanceChange.Cmp(expectedChange) >= 0,
-		"balance didn't increase as expected: got change %s, expected at least %s", balanceChange, expectedChange)
-
-	t.Log("Withdrawal completed successfully!")
+		t.Log("Withdrawal completed successfully!")
+	})
 }

--- a/espresso/docker-compose-op-geth.yml
+++ b/espresso/docker-compose-op-geth.yml
@@ -6,6 +6,7 @@ services:
       timeout: 2s
       retries: 40
     image: op-geth:espresso
+    pull_policy: never  # built by op-geth-sequencer
     depends_on:
       l2-genesis:
         condition: service_completed_successfully

--- a/espresso/docker-compose-op-geth.yml
+++ b/espresso/docker-compose-op-geth.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ./deployment:/deployment:ro
       - ./deployment/deployer:/deployer:ro
-      - ./deployment/l2-config:/config:ro
+      - l2-config:/config:ro
     environment:
       L1_RPC: http://l1-anvil:${L1_HTTP_PORT:?err}
       OP_HTTP_PORT: ${OP_HTTP_PORT:?err}

--- a/espresso/docker-compose-op-geth.yml
+++ b/espresso/docker-compose-op-geth.yml
@@ -5,18 +5,17 @@ services:
       interval: 3s
       timeout: 2s
       retries: 40
-    build:
-      context: ../
-      dockerfile: espresso/docker/op-geth/Dockerfile
     image: op-geth:espresso
     depends_on:
       l2-genesis:
         condition: service_completed_successfully
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
     volumes:
+      - ./deployment:/deployment:ro
+      - ./deployment/deployer:/deployer:ro
       - ./deployment/l2-config:/config:ro
     environment:
-      L1_RPC: http://l1-geth:${L1_HTTP_PORT:?err}
+      L1_RPC: http://l1-anvil:${L1_HTTP_PORT:?err}
       OP_HTTP_PORT: ${OP_HTTP_PORT:?err}
       OP_ENGINE_PORT: ${OP_ENGINE_PORT:?err}

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -58,6 +58,7 @@ services:
   l2-rollup:
     restart: on-failure
     image: op-geth:espresso
+    pull_policy: never  # built by op-geth-sequencer
     environment:
       - MODE=rollup
       - L1_RPC=http://l1-anvil:${L1_HTTP_PORT:?err}
@@ -80,6 +81,7 @@ services:
       l1-anvil:
         condition: service_healthy
     image: op-geth:espresso
+    pull_policy: never  # built by op-geth-sequencer
     environment:
       - MODE=genesis
       - HOME=/tmp
@@ -325,6 +327,7 @@ services:
   op-batcher-fallback:
     profiles: [ "default", "tee" ]
     image: op-batcher:espresso
+    pull_policy: never  # built by op-batcher
     depends_on:
       l1-anvil:
         condition: service_healthy

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: busybox
     command: >
       sh -c '
-        mkdir -p /deployment/l1-config /deployment/l2-config /deployment/deployer
+        mkdir -p /deployment/l1-config /deployment/deployer
         chown -R ${U_ID:-1000}:${GID:-1000} /deployment
         '
     volumes:
@@ -30,12 +30,16 @@ services:
       l1-data-init:
         condition: service_completed_successfully
     healthcheck:
-      test: [ "CMD-SHELL", "cast bn --rpc-url http://localhost:${L1_HTTP_PORT} > /dev/null 2>&1 || exit 1" ]
+      test:
+        [
+          "CMD-SHELL",
+          "cast bn --rpc-url http://localhost:${L1_HTTP_PORT} > /dev/null 2>&1 || exit 1",
+        ]
       interval: 3s
       timeout: 2s
       retries: 40
     image: ghcr.io/foundry-rs/foundry:v1.5.1
-    entrypoint: [ "sh", "-c" ]
+    entrypoint: ["sh", "-c"]
     command:
       - |
         anvil \
@@ -58,7 +62,7 @@ services:
   l2-rollup:
     restart: on-failure
     image: op-geth:espresso
-    pull_policy: never  # built by op-geth-sequencer
+    pull_policy: never # built by op-geth-sequencer
     environment:
       - MODE=rollup
       - L1_RPC=http://l1-anvil:${L1_HTTP_PORT:?err}
@@ -81,13 +85,13 @@ services:
       l1-anvil:
         condition: service_healthy
     image: op-geth:espresso
-    pull_policy: never  # built by op-geth-sequencer
+    pull_policy: never # built by op-geth-sequencer
     environment:
       - MODE=genesis
       - HOME=/tmp
       - L1_RPC=http://l1-anvil:${L1_HTTP_PORT:?err}
     volumes:
-      - ./deployment/l2-config:/config
+      - l2-config:/config
       - ./deployment/deployer:/deployer:ro
 
   op-geth-sequencer:
@@ -129,7 +133,7 @@ services:
       dockerfile: espresso/docker/op-stack/Dockerfile
       target: op-node-target
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:${ROLLUP_PORT}" ]
+      test: ["CMD", "curl", "-f", "http://localhost:${ROLLUP_PORT}"]
       interval: 3s
       timeout: 2s
       retries: 40
@@ -159,7 +163,7 @@ services:
     ports:
       - "${ROLLUP_PORT}:${ROLLUP_PORT}"
     volumes:
-      - ./deployment/l2-config:/config:ro
+      - l2-config:/config:ro
       - /etc/localtime:/etc/localtime:ro
       - op-node-seq:/data
     command:
@@ -180,7 +184,7 @@ services:
       dockerfile: espresso/docker/op-stack/Dockerfile
       target: op-node-target
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:${VERIFIER_PORT}" ]
+      test: ["CMD", "curl", "-f", "http://localhost:${VERIFIER_PORT}"]
       interval: 3s
       timeout: 2s
       retries: 40
@@ -210,7 +214,7 @@ services:
     ports:
       - "${VERIFIER_PORT}:${VERIFIER_PORT}"
     volumes:
-      - ./deployment/l2-config:/config:ro
+      - l2-config:/config:ro
     command:
       - op-node
       - --l2.jwt-secret=/config/jwt.txt
@@ -227,7 +231,7 @@ services:
       dockerfile: espresso/docker/op-stack/Dockerfile
       target: op-node-target
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:${CAFF_PORT}" ]
+      test: ["CMD", "curl", "-f", "http://localhost:${CAFF_PORT}"]
       interval: 3s
       timeout: 2s
       retries: 40
@@ -250,7 +254,7 @@ services:
     ports:
       - "${CAFF_PORT}:${CAFF_PORT}"
     volumes:
-      - ./deployment/l2-config:/config:ro
+      - l2-config:/config:ro
     command:
       - op-node
       - --l2.jwt-secret=/config/jwt.txt
@@ -271,9 +275,9 @@ services:
     restart: "no"
 
   op-batcher:
-    profiles: [ "default" ]
+    profiles: ["default"]
     image: op-batcher:espresso
-    pull_policy: never  # built by op-batcher-fallback
+    pull_policy: never # built by op-batcher-fallback
     # It is not necessary to specify all dependencies, but a good practice.
     depends_on:
       l1-anvil:
@@ -322,7 +326,7 @@ services:
       - --rpc.enable-admin
 
   op-batcher-fallback:
-    profiles: [ "default", "tee" ]
+    profiles: ["default", "tee"]
     build:
       context: ../
       dockerfile: espresso/docker/op-stack/Dockerfile
@@ -361,7 +365,7 @@ services:
   # `docker compose build` so the TEE batcher can skip the expensive
   # rebuild-from-source step at runtime and jump straight to EIF conversion.
   op-batcher-enclave-app:
-    profiles: [ "tee" ]
+    profiles: ["tee"]
     build:
       context: ../
       dockerfile: espresso/docker/op-stack/Dockerfile
@@ -369,14 +373,18 @@ services:
     image: op-batcher-enclave-app:espresso
 
   op-batcher-tee:
-    profiles: [ "tee" ]
+    profiles: ["tee"]
     build:
       context: ../
       dockerfile: espresso/docker/op-stack/Dockerfile
       target: op-batcher-enclave-target
     image: op-batcher-tee:espresso
     healthcheck:
-      test: [ "CMD-SHELL", "test -f /tmp/enclave-tools.pid && kill -0 $(cat /tmp/enclave-tools.pid) 2>/dev/null || exit 1" ]
+      test:
+        [
+          "CMD-SHELL",
+          "test -f /tmp/enclave-tools.pid && kill -0 $(cat /tmp/enclave-tools.pid) 2>/dev/null || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -431,7 +439,7 @@ services:
 
   # Legacy op-proposer (for non-succinct mode)
   op-proposer:
-    profiles: [ "legacy" ]
+    profiles: ["legacy"]
     build:
       context: ../
       dockerfile: espresso/docker/op-stack/Dockerfile
@@ -491,7 +499,7 @@ services:
     restart: unless-stopped
 
   op-proposer-tee:
-    profiles: [ "tee" ]
+    profiles: ["tee"]
     build:
       context: ../
       dockerfile: espresso/docker/op-stack/Dockerfile
@@ -519,7 +527,7 @@ services:
 
   # Legacy op-challenger (for non-succinct mode)
   op-challenger:
-    profiles: [ "legacy" ]
+    profiles: ["legacy"]
     build:
       context: ../
       dockerfile: espresso/docker/op-stack/Dockerfile
@@ -534,7 +542,7 @@ services:
         condition: service_started
     volumes:
       - ./deployment/deployer:/deployer:ro
-      - ./deployment/l2-config:/config:ro
+      - l2-config:/config:ro
       - op-data-challenger:/data
     environment:
       OP_CHALLENGER_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
@@ -599,7 +607,7 @@ services:
       # PORT configuration
       PORT: "3100"
     healthcheck:
-      test: [ "CMD-SHELL", "nc -z localhost 3100 || exit 1" ]
+      test: ["CMD-SHELL", "nc -z localhost 3100 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -612,7 +620,11 @@ services:
     ports:
       - "${ESPRESSO_ATTESTATION_VERIFIER_PORT}:${ESPRESSO_ATTESTATION_VERIFIER_PORT}"
     healthcheck:
-      test: [ "CMD-SHELL", "timeout 2 bash -c 'cat < /dev/null > /dev/tcp/localhost/${ESPRESSO_ATTESTATION_VERIFIER_PORT}' || exit 1" ]
+      test:
+        [
+          "CMD-SHELL",
+          "timeout 2 bash -c 'cat < /dev/null > /dev/tcp/localhost/${ESPRESSO_ATTESTATION_VERIFIER_PORT}' || exit 1",
+        ]
       interval: 5s
       timeout: 3s
       retries: 30
@@ -657,7 +669,7 @@ services:
       ESPRESSO_DEV_NODE_VERSION: "0.4"
 
   blockscout-db:
-    profiles: [ "default" ]
+    profiles: ["default"]
     image: postgres:14
     restart: on-failure
     environment:
@@ -668,7 +680,7 @@ services:
       - blockscout-db-data:/var/lib/postgresql/data
 
   blockscout:
-    profiles: [ "default" ]
+    profiles: ["default"]
     image: ghcr.io/blockscout/blockscout@sha256:7659f168e4e2f6b73dd559ae5278fe96ba67bc2905ea01b57a814c68adf5a9dc
     restart: always
     depends_on:
@@ -694,7 +706,7 @@ services:
       MIX_ENV: "prod"
 
   blockscout-frontend:
-    profiles: [ "default" ]
+    profiles: ["default"]
     image: ghcr.io/blockscout/frontend@sha256:4b69f44148414b55c6b8550bc3270c63c9f99e923d54ef0b307e762af6bac90a
     restart: always
     depends_on:
@@ -720,6 +732,7 @@ services:
       NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS: "18"
 
 volumes:
+  l2-config:
   op-data-seq:
   op-data-verifier:
   op-data-caff-node:

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -272,11 +272,8 @@ services:
 
   op-batcher:
     profiles: [ "default" ]
-    build:
-      context: ../
-      dockerfile: espresso/docker/op-stack/Dockerfile
-      target: op-batcher-target
     image: op-batcher:espresso
+    pull_policy: never  # built by op-batcher-fallback
     # It is not necessary to specify all dependencies, but a good practice.
     depends_on:
       l1-anvil:
@@ -326,8 +323,11 @@ services:
 
   op-batcher-fallback:
     profiles: [ "default", "tee" ]
+    build:
+      context: ../
+      dockerfile: espresso/docker/op-stack/Dockerfile
+      target: op-batcher-target
     image: op-batcher:espresso
-    pull_policy: never  # built by op-batcher
     depends_on:
       l1-anvil:
         condition: service_healthy

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -9,135 +9,62 @@
 ###########################################################################################
 
 services:
+  # Deployment directory init — ensure the bind-mount dirs exist with correct ownership.
   l1-data-init:
     image: busybox
     command: >
       sh -c '
         mkdir -p /deployment/l1-config /deployment/l2-config /deployment/deployer
-        mkdir -p /data/lighthouse-validator /data/lighthouse-beacon
-        chown -R ${U_ID:-1000}:${GID:-1000} /deployment /data
+        chown -R ${U_ID:-1000}:${GID:-1000} /deployment
         '
     volumes:
       - ./deployment:/deployment
-      - l1-data:/data
 
-  l1-genesis:
-    user: ${U_ID:-1000}:${GID:-1000}
-    restart: on-failure
+  # Anvil replaces l1-geth + lighthouse beacon + validator.
+  # It serves both EL JSON-RPC and a Beacon REST API on the same port,
+  # and provides offset-based finalization (finalized = head − 2 blocks
+  # with --slots-in-an-epoch 1).  This eliminates the ~110 s wait for
+  # real Casper FFG finality that the Lighthouse stack required.
+  l1-anvil:
     depends_on:
       l1-data-init:
         condition: service_completed_successfully
-    build:
-      context: ../
-      dockerfile: espresso/docker/l1-geth/Dockerfile
-    image: l1-geth:espresso
-    environment:
-      - MODE=genesis
-    volumes:
-      - ./deployment/l1-config:/config
-      - ./docker/l1-geth:/templates:ro
-      - l1-data:/data
-
-  l1-validator:
-    image: ${LIGHTHOUSE_IMAGE}
-    depends_on:
-      l1-genesis:
-        condition: service_completed_successfully
-      l1-geth:
-        condition: service_started
-      l1-beacon:
-        condition: service_started
-    volumes:
-      - l1-data:/data
-      - ./deployment/l1-config:/config:ro
-    command:
-      - lighthouse
-      - validator_client
-      - --testnet-dir
-      - /config
-      - --beacon-nodes
-      - http://l1-beacon:${L1_BEACON_PORT}
-      - --init-slashing-protection
-      - --datadir
-      - /data/lighthouse-validator
-      - --suggested-fee-recipient
-      - ${OPERATOR_ADDRESS}
-
-  l1-beacon:
-    image: ${LIGHTHOUSE_IMAGE}
-    depends_on:
-      l1-genesis:
-        condition: service_completed_successfully
-      l1-geth:
-        condition: service_started
-    volumes:
-      - l1-data:/data
-      - ./deployment/l1-config:/config:ro
-    command:
-      - lighthouse
-      - --datadir
-      - /data/lighthouse-beacon
-      - beacon_node
-      - --testnet-dir
-      - /config
-      - --execution-endpoint
-      - http://l1-geth:${L1_ENGINE_PORT}
-      - --execution-jwt
-      - /config/jwt.txt
-      - --http
-      - --http-address
-      - 0.0.0.0
-      - --http-port
-      - ${L1_BEACON_PORT}
-      - --http-allow-origin
-      - "*"
-      - --allow-insecure-genesis-sync
-      - --target-peers
-      - "0"
-      - --disable-deposit-contract-sync
-      - --disable-upnp
-    ports:
-      - "${L1_BEACON_PORT}:${L1_BEACON_PORT}"
-
-  l1-geth:
-    depends_on:
-      l1-genesis:
-        condition: service_completed_successfully
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:${L1_HTTP_PORT}" ]
+      test: [ "CMD-SHELL", "cast bn --rpc-url http://localhost:${L1_HTTP_PORT} > /dev/null 2>&1 || exit 1" ]
       interval: 3s
       timeout: 2s
       retries: 40
-    build:
-      context: ../
-      dockerfile: espresso/docker/l1-geth/Dockerfile
-    image: l1-geth:espresso
-    environment:
-      L1_HTTP_PORT: ${L1_HTTP_PORT:-8545}
-      L1_ENGINE_PORT: ${L1_ENGINE_PORT:-8551}
-      L1_CHAIN_ID: ${L1_CHAIN_ID:?err}
+    image: ghcr.io/foundry-rs/foundry:v1.5.1
+    entrypoint: [ "sh", "-c" ]
+    command:
+      - |
+        anvil \
+          --silent \
+          --host 0.0.0.0 \
+          --port ${L1_HTTP_PORT} \
+          --chain-id ${L1_CHAIN_ID} \
+          --block-time 3 \
+          --slots-in-an-epoch 1 \
+          --init /config/genesis.json \
+          --timestamp $$(date +%s) \
+          --disable-code-size-limit \
+          --base-fee 1000000000 \
+          --gas-limit 45000000
     volumes:
       - ./deployment/l1-config:/config:ro
-      - l1-data:/data
     ports:
-      - "${L1_HTTP_PORT}:${L1_HTTP_PORT}" # L1 RPC
-      - "${L1_ENGINE_PORT}:${L1_ENGINE_PORT}" # L1 Engine
+      - "${L1_HTTP_PORT}:${L1_HTTP_PORT}"
 
   l2-rollup:
     restart: on-failure
-    build:
-      context: ../
-      dockerfile: espresso/docker/op-geth/Dockerfile
     image: op-geth:espresso
     environment:
       - MODE=rollup
-      - L1_RPC=http://l1-geth:${L1_HTTP_PORT:?err}
+      - L1_RPC=http://l1-anvil:${L1_HTTP_PORT:?err}
       - OP_RPC=http://op-geth-sequencer:${OP_HTTP_PORT:?err}
     depends_on:
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
-      l1-genesis:
-        condition: service_completed_successfully
       op-geth-sequencer:
         condition: service_healthy
     volumes:
@@ -150,16 +77,13 @@ services:
     depends_on:
       l1-data-init:
         condition: service_completed_successfully
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
-    build:
-      context: ../
-      dockerfile: espresso/docker/op-geth/Dockerfile
     image: op-geth:espresso
     environment:
       - MODE=genesis
       - HOME=/tmp
-      - L1_RPC=http://l1-geth:${L1_HTTP_PORT:?err}
+      - L1_RPC=http://l1-anvil:${L1_HTTP_PORT:?err}
     volumes:
       - ./deployment/l2-config:/config
       - ./deployment/deployer:/deployer:ro
@@ -168,6 +92,9 @@ services:
     extends:
       file: docker-compose-op-geth.yml
       service: op-geth
+    build:
+      context: ../
+      dockerfile: espresso/docker/op-geth/Dockerfile
     volumes:
       - op-data-seq:/data
     ports:
@@ -210,13 +137,13 @@ services:
         condition: service_completed_successfully
       op-geth-sequencer:
         condition: service_healthy
-      l1-validator:
-        condition: service_started
+      l1-anvil:
+        condition: service_healthy
       eigenda-proxy:
         condition: service_healthy
     environment:
-      OP_NODE_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_NODE_L1_BEACON: http://l1-beacon:${L1_BEACON_PORT}
+      OP_NODE_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_NODE_L1_BEACON: http://l1-anvil:${L1_HTTP_PORT}
       OP_NODE_L2_ENGINE_RPC: http://op-geth-sequencer:${OP_ENGINE_PORT}
       OP_NODE_RPC_PORT: ${ROLLUP_PORT}
       OP_NODE_SAFEDB_PATH: /data/safedb
@@ -242,6 +169,7 @@ services:
       - --rpc.addr=0.0.0.0
       - --l1.http-poll-interval=1s
       - --l1.epoch-poll-interval=1s
+      - --l1.beacon.ignore
       - --p2p.disable=true
 
   op-node-verifier:
@@ -260,14 +188,14 @@ services:
         condition: service_completed_successfully
       op-geth-verifier:
         condition: service_started
-      l1-validator:
-        condition: service_started
+      l1-anvil:
+        condition: service_healthy
       eigenda-proxy:
         condition: service_healthy
     environment:
-      L1_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_NODE_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_NODE_L1_BEACON: http://l1-beacon:${L1_BEACON_PORT}
+      L1_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_NODE_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_NODE_L1_BEACON: http://l1-anvil:${L1_HTTP_PORT}
       OP_NODE_L2_ENGINE_RPC: http://op-geth-verifier:${OP_ENGINE_PORT}
       OP_NODE_RPC_PORT: ${VERIFIER_PORT}
       OP_NODE_ALTDA_ENABLED: "true"
@@ -288,6 +216,7 @@ services:
       - --rpc.addr=0.0.0.0
       - --l1.http-poll-interval=1s
       - --l1.epoch-poll-interval=1s
+      - --l1.beacon.ignore
       - --p2p.disable=true
 
   caff-node:
@@ -309,10 +238,10 @@ services:
       l2-rollup:
         condition: service_completed_successfully
     environment:
-      OP_NODE_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_NODE_L1_BEACON: http://l1-beacon:${L1_BEACON_PORT}
+      OP_NODE_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_NODE_L1_BEACON: http://l1-anvil:${L1_HTTP_PORT}
       OP_NODE_L2_ENGINE_RPC: http://op-geth-caff-node:${OP_ENGINE_PORT}
-      OP_NODE_ESPRESSO_L1_URL: http://l1-geth:${L1_HTTP_PORT}
+      OP_NODE_ESPRESSO_L1_URL: http://l1-anvil:${L1_HTTP_PORT}
       OP_NODE_ESPRESSO_LIGHT_CLIENT_ADDR: "0x703848f4c85f18e3acd8196c8ec91eb0b7bd0797"
       OP_NODE_ESPRESSO_URLS: http://espresso-dev-node:${ESPRESSO_SEQUENCER_API_PORT},http://espresso-dev-node:${ESPRESSO_SEQUENCER_API_PORT}
       OP_NODE_RPC_PORT: ${CAFF_PORT}
@@ -336,6 +265,7 @@ services:
       - --p2p.disable=true
       - --l1.http-poll-interval=1s
       - --l1.epoch-poll-interval=1s
+      - --l1.beacon.ignore
     restart: "no"
 
   op-batcher:
@@ -347,7 +277,7 @@ services:
     image: op-batcher:espresso
     # It is not necessary to specify all dependencies, but a good practice.
     depends_on:
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
       op-geth-sequencer:
         condition: service_started
@@ -362,8 +292,8 @@ services:
       attestation-service-zk:
         condition: service_healthy
     environment:
-      L1_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_BATCHER_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
+      L1_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_BATCHER_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
       OP_BATCHER_L2_ETH_RPC: http://op-geth-sequencer:${OP_HTTP_PORT}
       OP_BATCHER_ROLLUP_RPC: http://op-node-sequencer:${ROLLUP_PORT}
       OP_BATCHER_ESPRESSO_URLS: http://espresso-dev-node:${ESPRESSO_SEQUENCER_API_PORT},http://espresso-dev-node:${ESPRESSO_SEQUENCER_API_PORT}
@@ -393,14 +323,10 @@ services:
       - --rpc.enable-admin
 
   op-batcher-fallback:
-    profiles: [ "default" ]
-    build:
-      context: ../
-      dockerfile: espresso/docker/op-stack/Dockerfile
-      target: op-batcher-target
+    profiles: [ "default", "tee" ]
     image: op-batcher:espresso
     depends_on:
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
       op-geth-sequencer:
         condition: service_started
@@ -409,8 +335,8 @@ services:
       l2-genesis:
         condition: service_completed_successfully
     environment:
-      L1_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_BATCHER_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
+      L1_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_BATCHER_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
       OP_BATCHER_L2_ETH_RPC: http://op-geth-sequencer:${OP_HTTP_PORT}
       OP_BATCHER_ROLLUP_RPC: http://op-node-sequencer:${ROLLUP_PORT}
       OP_BATCHER_MAX_CHANNEL_DURATION: ${MAX_CHANNEL_DURATION:-32}
@@ -428,6 +354,17 @@ services:
       - --data-availability-type=calldata
       - --rpc.enable-admin
 
+  # Inner app image that Enclaver wraps into the EIF.  Built once during
+  # `docker compose build` so the TEE batcher can skip the expensive
+  # rebuild-from-source step at runtime and jump straight to EIF conversion.
+  op-batcher-enclave-app:
+    profiles: [ "tee" ]
+    build:
+      context: ../
+      dockerfile: espresso/docker/op-stack/Dockerfile
+      target: op-batcher-enclave-app
+    image: op-batcher-enclave-app:espresso
+
   op-batcher-tee:
     profiles: [ "tee" ]
     build:
@@ -442,7 +379,7 @@ services:
       retries: 3
       start_period: 60s
     depends_on:
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
       op-geth-sequencer:
         condition: service_started
@@ -469,13 +406,13 @@ services:
       ENCLAVE_CPU_COUNT: ${ENCLAVE_CPU_COUNT:-2}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ..:/source:ro
-      - ./scripts/batcher-enclave-tool-image.sh:/app/espresso/scripts/batcher-enclave-tool-image.sh:ro
       - /tmp:/tmp
+      - ./deployment:/app/deployment:ro
     privileged: true
     devices:
       - /dev/nitro_enclaves:/dev/nitro_enclaves
     restart: "no"
+    stop_grace_period: 30s
     command:
       - sh
       - -c
@@ -487,7 +424,7 @@ services:
         export ESPRESSO_URL1="http://127.0.0.1:${ESPRESSO_SEQUENCER_API_PORT}"
         export ESPRESSO_ATTESTATION_SERVICE_URL="http://127.0.0.1:${ESPRESSO_ATTESTATION_VERIFIER_PORT}"
         export EIGENDA_PROXY_URL="http://127.0.0.1:${EIGENDA_PROXY_PORT}"
-        /source/espresso/docker/op-batcher-tee/run-enclave.sh
+        exec /app/run-enclave.sh
 
   # Legacy op-proposer (for non-succinct mode)
   op-proposer:
@@ -510,7 +447,7 @@ services:
       - ../packages/contracts-bedrock/lib/superchain-registry/ops/testdata/monorepo:/config
       - ./deployment/deployer:/deployer
     environment:
-      OP_PROPOSER_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
+      OP_PROPOSER_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
       OP_PROPOSER_ROLLUP_RPC: http://op-node-sequencer:${ROLLUP_PORT}
       OP_PROPOSER_PROPOSAL_INTERVAL: 6s
       OP_PROPOSER_MNEMONIC: "test test test test test test test test test test test junk"
@@ -537,8 +474,8 @@ services:
     env_file:
       - ./deployment/deployer/succinct.env
     environment:
-      L1_RPC: http://l1-geth:${L1_HTTP_PORT}
-      L1_BEACON_RPC: http://l1-beacon:${L1_BEACON_PORT}
+      L1_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      L1_BEACON_RPC: http://l1-anvil:${L1_HTTP_PORT}
       L2_RPC: http://op-geth-sequencer:${OP_HTTP_PORT}
       L2_NODE_RPC: http://op-node-sequencer:${ROLLUP_PORT}
       PRIVATE_KEY: ${PROPOSER_PRIVATE_KEY}
@@ -570,7 +507,7 @@ services:
       - ../packages/contracts-bedrock/lib/superchain-registry/ops/testdata/monorepo:/config
       - ./deployment/deployer:/deployer
     environment:
-      OP_PROPOSER_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
+      OP_PROPOSER_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
       OP_PROPOSER_ROLLUP_RPC: http://op-node-sequencer:${ROLLUP_PORT}
       OP_PROPOSER_PROPOSAL_INTERVAL: 6s
       OP_PROPOSER_MNEMONIC: "test test test test test test test test test test test junk"
@@ -586,10 +523,8 @@ services:
       target: op-challenger-target
     image: op-challenger:espresso
     depends_on:
-      l1-geth:
-        condition: service_started
-      l1-beacon:
-        condition: service_started
+      l1-anvil:
+        condition: service_healthy
       op-node-sequencer:
         condition: service_started
       op-geth-sequencer:
@@ -599,8 +534,8 @@ services:
       - ./deployment/l2-config:/config:ro
       - op-data-challenger:/data
     environment:
-      OP_CHALLENGER_L1_ETH_RPC: http://l1-geth:${L1_HTTP_PORT}
-      OP_CHALLENGER_L1_BEACON: http://l1-beacon:${L1_BEACON_PORT}
+      OP_CHALLENGER_L1_ETH_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      OP_CHALLENGER_L1_BEACON: http://l1-anvil:${L1_HTTP_PORT}
       OP_CHALLENGER_ROLLUP_RPC: http://op-node-sequencer:${ROLLUP_PORT}
       OP_CHALLENGER_L2_ETH_RPC: http://op-geth-sequencer:${OP_HTTP_PORT}
       OP_CHALLENGER_MNEMONIC: "test test test test test test test test test test test junk"
@@ -615,10 +550,8 @@ services:
     profiles: ["default"]
     image: ghcr.io/espressosystems/op-succinct/op-succinct-lite-challenger-celo:sha-15d94cc
     depends_on:
-      l1-geth:
-        condition: service_started
-      l1-beacon:
-        condition: service_started
+      l1-anvil:
+        condition: service_healthy
       op-node-sequencer:
         condition: service_started
       op-geth-sequencer:
@@ -634,8 +567,8 @@ services:
     env_file:
       - ./deployment/deployer/succinct.env
     environment:
-      L1_RPC: http://l1-geth:${L1_HTTP_PORT}
-      L1_BEACON_RPC: http://l1-beacon:${L1_BEACON_PORT}
+      L1_RPC: http://l1-anvil:${L1_HTTP_PORT}
+      L1_BEACON_RPC: http://l1-anvil:${L1_HTTP_PORT}
       L2_RPC: http://op-geth-verifier:${OP_HTTP_PORT}
       L2_NODE_RPC: http://op-node-verifier:${VERIFIER_PORT}
       PRIVATE_KEY: ${OPERATOR_PRIVATE_KEY}
@@ -699,7 +632,7 @@ services:
   espresso-dev-node:
     image: ${ESPRESSO_DEV_NODE_IMAGE}
     depends_on:
-      l1-geth:
+      l1-anvil:
         condition: service_healthy
     ports:
       - "${ESPRESSO_SEQUENCER_API_PORT}:${ESPRESSO_SEQUENCER_API_PORT}"
@@ -714,7 +647,7 @@ services:
       ESPRESSO_DEV_NODE_L1_DEPLOYMENT: skip
       RUST_BACKTRACE: 1
       ESPRESSO_SEQUENCER_STORAGE_PATH: /data/espresso
-      ESPRESSO_SEQUENCER_L1_PROVIDER: http://l1-geth:${L1_HTTP_PORT}
+      ESPRESSO_SEQUENCER_L1_PROVIDER: http://l1-anvil:${L1_HTTP_PORT}
       ESPRESSO_DEPLOYER_ACCOUNT_INDEX: 0
       ESPRESSO_DEV_NODE_EPOCH_HEIGHT: "4294967295"
       ESPRESSO_SEQUENCER_ETH_MNEMONIC: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
@@ -784,7 +717,6 @@ services:
       NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS: "18"
 
 volumes:
-  l1-data:
   op-data-seq:
   op-data-verifier:
   op-data-caff-node:

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       op-geth-sequencer:
         condition: service_healthy
     volumes:
-      - ./deployment/l2-config:/config
+      - l2-config:/config
       - ./deployment/deployer:/deployer:ro
 
   l2-genesis:

--- a/espresso/docker-compose.yml
+++ b/espresso/docker-compose.yml
@@ -77,7 +77,6 @@ services:
       - ./deployment/deployer:/deployer:ro
 
   l2-genesis:
-    user: "${U_ID:-1000}:${GID:-1000}"
     restart: on-failure
     depends_on:
       l1-data-init:

--- a/espresso/docker/l1-geth/Dockerfile
+++ b/espresso/docker/l1-geth/Dockerfile
@@ -90,12 +90,13 @@ COPY --from=builder /go/bin/eth2-val-tools /usr/local/bin/eth2-val-tools
 # Create data and templates directories
 RUN mkdir -p /data /templates
 
-# Include the deployment artifacts and the initialization scripts for the L1 services.
+# Include the initialization scripts for the L1 services.
 COPY espresso/docker/l1-geth/beacon-config.yaml /templates/
 COPY espresso/docker/l1-geth/devnet-genesis-template.json /templates/
 COPY espresso/docker/l1-geth/mnemonics.yaml /templates/
 COPY espresso/docker/l1-geth/l1-geth-init.sh /l1-geth-init.sh
-COPY espresso/deployment/ /deployment/
+# Deployment artifacts are mounted via docker-compose volumes at runtime
+# (./deployment:/deployment) rather than baked into the image.
 
 # Run the initialization script.
 RUN chmod +x /l1-geth-init.sh

--- a/espresso/docker/l1-geth/Dockerfile.dockerignore
+++ b/espresso/docker/l1-geth/Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# Allowlist-based dockerignore for espresso l1-geth builds.
+# This Dockerfile doesn't build Go code from the monorepo — it only copies
+# config files and deployment artifacts. Almost everything can be excluded.
+*
+
+!/espresso/docker/l1-geth
+
+# espresso/deployment is runtime-generated and no longer baked into the image;
+# services mount it via docker-compose volumes instead.

--- a/espresso/docker/op-batcher-tee/run-enclave.sh
+++ b/espresso/docker/op-batcher-tee/run-enclave.sh
@@ -50,7 +50,7 @@ export BATCH_AUTHENTICATOR_ADDRESS
 if [ -n "$ESPRESSO_LIGHT_CLIENT_ADDR" ]; then
     echo "Using ESPRESSO_LIGHT_CLIENT_ADDR from environment variable"
 else
-    # Decaf light client address for ETH Sepoliaß
+    # Decaf light client address for ETH Sepolia
     ESPRESSO_LIGHT_CLIENT_ADDR="0x303872bb82a191771321d4828888920100d0b3e4"
     echo "ESPRESSO_LIGHT_CLIENT_ADDR not set, using default"
 fi

--- a/espresso/docker/op-batcher-tee/run-enclave.sh
+++ b/espresso/docker/op-batcher-tee/run-enclave.sh
@@ -34,7 +34,7 @@ DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-aws}"  # 'local' or 'aws'
 if [ -n "$BATCH_AUTHENTICATOR_ADDRESS" ]; then
     echo "Using BATCH_AUTHENTICATOR_ADDRESS from environment variable"
 else
-    address_from_state=$(jq -r '.opChainDeployments[0].batchAuthenticatorAddress' /source/espresso/deployment/deployer/state.json 2>/dev/null)
+    address_from_state=$(jq -r '.opChainDeployments[0].batchAuthenticatorAddress' /app/deployment/deployer/state.json 2>/dev/null)
     if [ -n "$address_from_state" ] && [ "$address_from_state" != "null" ]; then
         BATCH_AUTHENTICATOR_ADDRESS="$address_from_state"
         echo "Using BATCH_AUTHENTICATOR_ADDRESS from state.json"
@@ -131,18 +131,20 @@ if stale=$(docker ps -q --filter "name=batcher-enclaver") && [ -n "$stale" ]; th
     docker rm -f $stale
 fi
 
-# Build the enclave image
-echo "Building enclave image with tag: $TAG"
-cd /source
+# Build the EIF from the pre-built app image (built during `docker compose build`).
+# This skips the expensive Docker rebuild-from-source step and goes straight to
+# Enclaver EIF conversion, saving ~3-10 minutes per startup.
+APP_IMAGE="${APP_IMAGE:-op-batcher-enclave-app:espresso}"
+echo "Building EIF from pre-built app image: $APP_IMAGE (tag: $TAG)"
 
-if ! enclave-tools build --op-root /source --tag "$TAG" --cpu-count "$CPU_COUNT" --memory-mb "$MEMORY_MB" 2>&1 | tee /tmp/build_output.log; then
-    echo "ERROR: Failed to build enclave image"
+if ! enclave-tools build-eif --app-image "$APP_IMAGE" --eif-tag "$TAG" --cpu-count "$CPU_COUNT" --memory-mb "$MEMORY_MB" 2>&1 | tee /tmp/build_output.log; then
+    echo "ERROR: Failed to build EIF image"
     echo "Build output was:"
     cat /tmp/build_output.log
     exit 1
 fi
 
-echo "Build completed successfully"
+echo "EIF build completed successfully"
 
 # Extract PCR0 from build output
 # Works whether the line is `... PCR0: 0xABCD ...` or `... PCR0=abcd123 ...`
@@ -192,19 +194,18 @@ if [ "$DEPLOYMENT_MODE" = "local" ]; then
             if kill -0 "$STORED_PID" 2>/dev/null; then
                 echo "Terminating enclave-tools process (PID: $STORED_PID)"
                 kill -TERM "$STORED_PID" 2>/dev/null || true
-                sleep 5
-                kill -KILL "$STORED_PID" 2>/dev/null || true
             fi
             rm -f "$PID_FILE"
         fi
 
-        # Clean up any remaining enclave containers
+        # Force-kill tracked enclave runner containers (tracker stores
+        # container IDs).  docker rm -f sends SIGKILL immediately, which
+        # also causes enclaver to terminate the Nitro Enclave VM.
         if [ -f "$CONTAINER_TRACKER_FILE" ]; then
-            while IFS= read -r container_id; do
-                if [ -n "$container_id" ] && docker ps -q --filter id="$container_id" | grep -q "$container_id"; then
-                    echo "Stopping tracked enclave container: $container_id"
-                    docker stop "$container_id" 2>/dev/null || true
-                    docker rm "$container_id" 2>/dev/null || true
+            while IFS= read -r cid; do
+                if [ -n "$cid" ]; then
+                    echo "Force-removing enclave container: $cid"
+                    docker rm -f "$cid" 2>/dev/null || true
                 fi
             done < "$CONTAINER_TRACKER_FILE"
             rm -f "$CONTAINER_TRACKER_FILE"
@@ -284,7 +285,7 @@ echo "  Started: $STARTED_AT"
 
 # Setup status tracking for local deployment
 if [ "$DEPLOYMENT_MODE" = "local" ]; then
-    echo "$CONTAINER_NAME" >> "$CONTAINER_TRACKER_FILE"
+    echo "$CONTAINER_ID" >> "$CONTAINER_TRACKER_FILE"
 
     # Create initial status file
     cat > "$STATUS_FILE" <<EOF
@@ -368,7 +369,11 @@ EOF
     fi
 
     MONITOR_COUNT=$((MONITOR_COUNT + 1))
-    sleep "$MONITOR_INTERVAL"
+    # sleep in the background and `wait` for it.  `wait` is a shell
+    # builtin that is interrupted immediately by trapped signals, unlike
+    # a foreground `sleep` which defers signal delivery until it returns.
+    sleep "$MONITOR_INTERVAL" &
+    wait $! 2>/dev/null || true
 done
 
 echo "Enclave monitoring ended"

--- a/espresso/docker/op-geth/Dockerfile
+++ b/espresso/docker/op-geth/Dockerfile
@@ -9,7 +9,7 @@ ARG GIT_DATE
 # CGO builder for components that need Espresso crypto linking (go.mod requires go >= 1.24.0)
 FROM golang:1.24-alpine AS op-cgo-builder
 # Install dependencies
-RUN apk add musl-dev gcc g++ curl tar gzip make linux-headers git jq bash yq just
+RUN apk add musl-dev gcc g++ curl tar gzip make linux-headers git jq bash
 
 # Go sources
 COPY ./go.mod /app/go.mod
@@ -53,9 +53,9 @@ RUN case $(uname -m) in \
 # Copy binary from builder stage.
 COPY --from=op-deployer-builder /op-deployer /usr/local/bin/
 
-# Include the deployment artifacts and the initialization script.
-COPY espresso/deployment/ /deployment/
-COPY espresso/deployment/deployer /deployer
+# Deployment artifacts are mounted via docker-compose volumes at runtime
+# (./deployment:/deployment, ./deployment/deployer:/deployer, etc.)
+# rather than baked into the image.
 COPY espresso/docker/op-geth/op-geth-init.sh /op-geth-init.sh
 
 # Run the initialization script.

--- a/espresso/docker/op-geth/Dockerfile.dockerignore
+++ b/espresso/docker/op-geth/Dockerfile.dockerignore
@@ -1,0 +1,46 @@
+# Allowlist-based dockerignore for espresso op-geth builds.
+# The op-geth Dockerfile needs Go source for op-deployer and geth builds,
+# plus espresso deployment artifacts and init scripts.
+*
+
+# Build system
+!/go.mod
+!/go.sum
+
+# Go source directories needed for op-deployer and geth builds
+!/cannon
+!/devnet-sdk
+!/espresso
+!/op-alt-da
+!/op-batcher
+!/op-chain-ops
+!/op-challenger
+!/op-conductor
+!/op-core
+!/op-deployer
+!/op-dispute-mon
+!/op-dripper
+!/op-e2e/e2eutils
+!/op-faucet
+!/op-interop-filter
+!/op-interop-mon
+!/op-node
+!/op-preimage
+!/op-program
+!/op-proposer
+!/op-service
+!/op-supernode
+!/op-supervisor
+!/op-test-sequencer
+!/op-wheel
+
+# Go package embedded in contracts-bedrock (imported by op-node)
+!/packages/contracts-bedrock/snapshots
+
+# Exclude build outputs and test fixtures from allowed dirs
+**/bin
+**/testdata
+**/tests
+
+# Exclude runtime-generated deployment artifacts (same rationale as op-stack).
+espresso/deployment

--- a/espresso/docker/op-stack/Dockerfile
+++ b/espresso/docker/op-stack/Dockerfile
@@ -63,7 +63,7 @@ ARG OP_NODE_VERSION=v0.0.0
 ENV GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_NODE_VERSION"
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   cd /app/op-node && mkdir -p bin && \
-  CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static" -X main.GitCommit=$GITCOMMIT -X main.GitDate=$GITDATE -X github.com/ethereum-optimism/optimism/op-node/version.Version=$VERSION -X github.com/ethereum-optimism/optimism/op-node/version.Meta=' -o bin/op-node ./cmd/main.go
+  CGO_ENABLED=0 go build -ldflags '-extldflags "-static" -X main.GitCommit=$GITCOMMIT -X main.GitDate=$GITDATE -X github.com/ethereum-optimism/optimism/op-node/version.Version=$VERSION -X github.com/ethereum-optimism/optimism/op-node/version.Meta=' -o bin/op-node ./cmd/main.go
 
 # Build op-batcher
 FROM builder AS op-batcher-builder
@@ -110,54 +110,58 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
   cd /app/op-deployer && just build-go
 
 
+# Download Aztec SRS once; COPY --from into each target that needs it.
+FROM $TARGET_BASE_IMAGE AS aztec-srs
+ADD "https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin" /aztec/kzg10-aztec20-srs-1048584.bin
+
 # Final runtime images
 FROM $TARGET_BASE_IMAGE AS op-node-target
-RUN apk add gcc
+RUN apk add libgcc
 ENV AZTEC_SRS_PATH=/aztec/kzg10-aztec20-srs-1048584.bin
-ADD "https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin" /aztec/kzg10-aztec20-srs-1048584.bin
+COPY --from=aztec-srs /aztec/kzg10-aztec20-srs-1048584.bin /aztec/kzg10-aztec20-srs-1048584.bin
 COPY --from=op-node-builder /app/op-node/bin/op-node /usr/local/bin/
 
 # Create config directory
 RUN mkdir -p /config
 
-# Include the deployment and contracts.
-COPY espresso/deployment/ /deployment/
+# Deployment artifacts are mounted via docker-compose volumes at runtime
+# (./deployment/l2-config:/config, ./deployment/deployer:/deployer, etc.)
+# rather than baked into the image, so that runtime-generated files in
+# espresso/deployment/ don't bust the Docker build cache.
 
 CMD ["op-node"]
 
 FROM $TARGET_BASE_IMAGE AS op-batcher-target
-RUN apk add gcc
+RUN apk add libgcc
 ENV AZTEC_SRS_PATH=/aztec/kzg10-aztec20-srs-1048584.bin
-ADD "https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin" /aztec/kzg10-aztec20-srs-1048584.bin
+COPY --from=aztec-srs /aztec/kzg10-aztec20-srs-1048584.bin /aztec/kzg10-aztec20-srs-1048584.bin
 COPY --from=op-batcher-builder /app/op-batcher/bin/op-batcher /usr/local/bin/
 CMD ["op-batcher"]
 
 # Inner image that Enclaver wraps into the EIF. Contains only the batcher
 # binary and the enclave entrypoint (socat proxying, arg routing via nc).
 FROM $TARGET_BASE_IMAGE AS op-batcher-enclave-app
-RUN apk add gcc bash socat trurl
-ENV AZTEC_SRS_PATH /aztec/kzg10-aztec20-srs-1048584.bin
-ADD "https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin" /aztec/kzg10-aztec20-srs-1048584.bin
+RUN apk add libgcc bash socat trurl
+ENV AZTEC_SRS_PATH=/aztec/kzg10-aztec20-srs-1048584.bin
+COPY --from=aztec-srs /aztec/kzg10-aztec20-srs-1048584.bin /aztec/kzg10-aztec20-srs-1048584.bin
 COPY --from=op-batcher-builder /app/op-batcher/bin/op-batcher /usr/local/bin/
 COPY op-batcher/enclave-entrypoint.bash /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]
 
+# Runtime image for TEE batcher.  Uses `enclave-tools build-eif` with the
+# pre-built op-batcher-enclave-app image (eliminating a full rebuild from
+# source at startup) then runs the resulting EIF via `enclave-tools run`.
 FROM $TARGET_BASE_IMAGE AS op-batcher-enclave-target
-RUN apk add gcc docker bash jq curl wget
+RUN apk add libgcc docker bash jq curl wget
 # Install enclaver for EIF creation
-RUN curl -L https://github.com/enclaver-io/enclaver/releases/download/v0.5.0/enclaver-linux-x86_64-v0.5.0.tar.gz | tar xz --strip-components=1 -C /usr/local/bin enclaver-linux-x86_64-v0.5.0/enclaver
-# Copy source code
-COPY --from=builder /app /source
-WORKDIR /source
-# Include the deployment state for contract addresses
-COPY espresso/deployment/ /source/espresso/deployment/
-# run-enclave.sh — build from source + register PCR0 + run (local/dev)
-# run-eif.sh lives in the infra repo (not shipped in this image)
-COPY espresso/docker/op-batcher-tee/run-enclave.sh ./espresso/docker/op-batcher-tee/run-enclave.sh
-RUN chmod +x ./espresso/docker/op-batcher-tee/run-enclave.sh
-ENV AZTEC_SRS_PATH=/aztec/kzg10-aztec20-srs-1048584.bin
-ADD "https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin" /aztec/kzg10-aztec20-srs-1048584.bin
+RUN curl -L https://github.com/enclaver-io/enclaver/releases/download/v0.6.1/enclaver-linux-x86_64-v0.6.1.tar.gz | tar xz --strip-components=1 -C /usr/local/bin enclaver-linux-x86_64-v0.6.1/enclaver
+WORKDIR /app
+# Deployment state (state.json with BatchAuthenticatorAddress) is mounted via
+# docker-compose volumes at /app/deployment rather than baked into the image.
+# run-enclave.sh — build EIF from pre-built app image + register PCR0 + run
+COPY espresso/docker/op-batcher-tee/run-enclave.sh /app/run-enclave.sh
+RUN chmod +x /app/run-enclave.sh
 COPY --from=enclave-tools-builder /app/op-batcher/bin/enclave-tools /usr/local/bin/
 CMD ["enclave-tools"]
 
@@ -166,7 +170,7 @@ RUN apk add jq
 COPY espresso/docker/op-stack/entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh
 COPY --from=op-proposer-builder /app/op-proposer/bin/op-proposer /usr/local/bin/
-COPY --from=op-proposer-builder /app/espresso/deployment/deployer /deployer
+# /deployer is mounted via docker-compose volumes (./deployment/deployer:/deployer)
 ENV ENV_PREFIX=OP_PROPOSER
 ENTRYPOINT [ "/bin/entrypoint.sh" ]
 CMD ["op-proposer"]

--- a/espresso/docker/op-stack/Dockerfile.dockerignore
+++ b/espresso/docker/op-stack/Dockerfile.dockerignore
@@ -1,0 +1,60 @@
+# Allowlist-based dockerignore for espresso op-stack builds.
+# Mirrors the strategy in ops/docker/op-stack-go/Dockerfile.dockerignore.
+# node_modules, packages (git submodules, Solidity libs), devnet dirs etc.
+# add up to >1 GB of unnecessary build context if not excluded.
+*
+
+# Build system
+!/go.mod
+!/go.sum
+!/mise.toml
+!/justfiles
+
+# Go source directories (all packages in the single-module monorepo)
+!/cannon
+!/devnet-sdk
+!/espresso
+!/op-alt-da
+!/op-batcher
+!/op-chain-ops
+!/op-challenger
+!/op-conductor
+!/op-core
+!/op-deployer
+!/op-dispute-mon
+!/op-dripper
+!/op-e2e/e2eutils
+!/op-faucet
+!/op-interop-filter
+!/op-interop-mon
+!/op-node
+!/op-preimage
+!/op-program
+!/op-proposer
+!/op-service
+!/op-supernode
+!/op-supervisor
+!/op-test-sequencer
+!/op-wheel
+
+# Go package embedded in contracts-bedrock (imported by op-node)
+!/packages/contracts-bedrock/snapshots
+
+# Forge artifacts needed by op-deployer-target
+!/packages/contracts-bedrock/forge-artifacts
+
+# Exclude build outputs and test fixtures from allowed dirs
+**/bin
+**/testdata
+**/tests
+
+# Exclude compiled test contract artifacts (~1.2 GB of test harnesses not needed
+# at runtime). Script artifacts (*.s.sol) are kept — op-deployer runs them in
+# its embedded EVM.
+packages/contracts-bedrock/forge-artifacts/*.t.sol
+
+# Exclude runtime-generated deployment artifacts.  These files change on every
+# devnet run and bust the COPY layer cache, forcing all Go builder stages to
+# rebuild.  Services that need deployment data mount it via docker-compose
+# volumes instead.
+espresso/deployment

--- a/espresso/environment/enclave_helpers.go
+++ b/espresso/environment/enclave_helpers.go
@@ -39,7 +39,7 @@ import (
 const (
 	ENCLAVE_INTERMEDIATE_IMAGE_TAG = "op-batcher-enclave:tests"
 	ENCLAVE_IMAGE_TAG              = "op-batcher-enclaver:tests"
-	ESPRESSO_ENABLE_ENCLAVE_TESTS  = "ESPRESSO_RUN_ENCLAVE_TESTS"
+	ESPRESSO_RUN_ENCLAVE_TESTS     = "ESPRESSO_RUN_ENCLAVE_TESTS"
 
 	// TeeTypeNitro corresponds to IEspressoTEEVerifier.TeeType.NITRO enum value
 	TeeTypeNitro uint8 = 1
@@ -47,9 +47,19 @@ const (
 	ServiceTypeBatchPoster uint8 = 0
 )
 
-// Skips the calling test if `ESPRESSO_ENABLE_ENCLAVE_TESTS` is not set.
+func HasTee() (bool, error) {
+	_, hasTee := os.LookupEnv(ESPRESSO_RUN_ENCLAVE_TESTS)
+	if hasTee {
+		if _, err := os.Stat("/dev/nitro_enclaves"); os.IsNotExist(err) {
+			return false, fmt.Errorf("/dev/nitro_enclaves does not exist; cannot run enclave tests without Nitro Enclaves support")
+		}
+	}
+	return hasTee, nil
+}
+
+// Skips the calling test if `ESPRESSO_RUN_ENCLAVE_TESTS` is not set.
 func RunOnlyWithEnclave(t *testing.T) {
-	_, doRun := os.LookupEnv(ESPRESSO_ENABLE_ENCLAVE_TESTS)
+	_, doRun := os.LookupEnv(ESPRESSO_RUN_ENCLAVE_TESTS)
 	if !doRun {
 		t.SkipNow()
 	}

--- a/espresso/scripts/logs.sh
+++ b/espresso/scripts/logs.sh
@@ -7,10 +7,7 @@
 
 # Valid service names
 VALID_SERVICES=(
-    "l1-genesis"
-    "l1-geth"
-    "l1-beacon"
-    "l1-validator"
+    "l1-anvil"
     "espresso-dev-node"
     "l2-genesis"
     "op-geth-sequencer"

--- a/flake.lock
+++ b/flake.lock
@@ -18,62 +18,13 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "foundry": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1742548208,
-        "narHash": "sha256-6+OKz31cUtD5WHeq/FUxOrrpAysex49PKP1kcvIU7Xo=",
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "rev": "3862940c7d1133b9c743b764d60a635c3b48cfb0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "shazow",
-        "ref": "main",
-        "repo": "foundry.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666753130,
-        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {
@@ -83,11 +34,61 @@
         "type": "github"
       }
     },
+    "pkgs-anvil": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      }
+    },
+    "pkgs-foundry": {
+      "locked": {
+        "lastModified": 1753722563,
+        "narHash": "sha256-FK8iq76wlacriq3u0kFCehsRYTAqjA9nfprpiSWRWIc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "648f70160c03151bc2121d179291337ad6bc564b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "648f701",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pkgs-go": {
+      "locked": {
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "ebe4301",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs",
+        "pkgs-anvil": "pkgs-anvil",
+        "pkgs-foundry": "pkgs-foundry",
+        "pkgs-go": "pkgs-go"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,13 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    foundry.url = "github:shazow/foundry.nix/main";
+
+    # Pinned to commit that has Go 1.23.8
+    pkgs-go.url = "github:nixos/nixpkgs/ebe4301";
+    # Foundry 1.2.3 — pinned for the Solidity compiler (forge)
+    pkgs-foundry.url = "github:nixos/nixpkgs/648f701";
+    # Foundry 1.5.1 — newer anvil with built-in Beacon REST API
+    pkgs-anvil.url = "github:nixos/nixpkgs/6201e203d09599479a3b3450ed24fa81537ebc4e";
   };
 
   outputs =
@@ -10,19 +16,18 @@
     inputs.flake-utils.lib.eachDefaultSystem (
       system:
       let
-        overlays = [
-          inputs.foundry.overlay
-        ];
-        pkgs = import inputs.nixpkgs { inherit overlays system; };
+        pkgs = import inputs.nixpkgs { inherit system; };
 
-        go_1_23_8 = pkgs.go_1_23.overrideAttrs (oldAttrs: {
-          version = "1.23.8";
+        go_1_23_8 = (import inputs.pkgs-go { inherit system; }).go_1_23;
+        foundry_1_2_3 = (import inputs.pkgs-foundry { inherit system; }).foundry;
 
-          src = pkgs.fetchurl {
-            url = "https://go.dev/dl/go1.23.8.src.tar.gz";
-            sha256 = "sha256-DKHx436iVePOKDrz9OYoUC+0RFh9qYelu5bWxvFZMNQ=";
-          };
-        });
+        # Newer Foundry (1.5.1) for anvil only — includes built-in Beacon REST API
+        # needed by the devnet L1.  We extract just the anvil binary so it doesn't
+        # shadow forge/cast from the pinned 1.2.3 package.
+        anvil_1_5_1 = pkgs.runCommand "anvil-1.5.1" { } ''
+          mkdir -p $out/bin
+          ln -s ${(import inputs.pkgs-anvil { inherit system; }).foundry}/bin/anvil $out/bin/anvil
+        '';
 
         espressoGoLibFile = pkgs.stdenv.mkDerivation rec {
           pname = "libespresso_crypto_helper";
@@ -91,60 +96,18 @@
           doCheck = false;
         };
 
-        # Pinned to stable 1.2.3 rather than the nightly used elsewhere.
-        # The nightly (654c8f01) added strict vm.getCode artifact matching that errors
-        # when two contracts share the same name (e.g. src/universal/Proxy.sol and
-        # OZ v5's proxy/Proxy.sol). Fixing every upstream call-site would touch many
-        # Celo/OP-stack files.
-        foundry-bin-1_2_3 =
-          let
-            version = "1.2.3";
-            srcs = {
-              "x86_64-linux" = pkgs.fetchurl {
-                url = "https://github.com/foundry-rs/foundry/releases/download/v${version}/foundry_v${version}_linux_amd64.tar.gz";
-                sha256 = "sha256-ggLzjxY1wnk7LRpP5EOub3MVGQ3G7tIZ15aaQKt4ooY=";
-              };
-              "aarch64-linux" = pkgs.fetchurl {
-                url = "https://github.com/foundry-rs/foundry/releases/download/v${version}/foundry_v${version}_linux_arm64.tar.gz";
-                sha256 = "sha256-cGEv0dqd86izVIQhTk8rN7odbEEVCElJBkLXoFPDHqo=";
-              };
-              "x86_64-darwin" = pkgs.fetchurl {
-                url = "https://github.com/foundry-rs/foundry/releases/download/v${version}/foundry_v${version}_darwin_amd64.tar.gz";
-                sha256 = "sha256-4+K0JcfhuMhT7UVCdrIP9QD6gtZcyVrK0iW0twY63Uo=";
-              };
-              "aarch64-darwin" = pkgs.fetchurl {
-                url = "https://github.com/foundry-rs/foundry/releases/download/v${version}/foundry_v${version}_darwin_arm64.tar.gz";
-                sha256 = "sha256-o/PxQXp6AqFpQun8hkGNASHC2QTBE/6xsmydadxvKH0=";
-              };
-            };
-          in
-          pkgs.stdenv.mkDerivation {
-            pname = "foundry-bin";
-            inherit version;
-            src = srcs.${system};
-            nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
-            buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
-            dontUnpack = true;
-            installPhase = ''
-              mkdir -p $out/bin
-              tar -xzf $src -C $out/bin forge cast anvil chisel
-              chmod +x $out/bin/forge $out/bin/cast $out/bin/anvil $out/bin/chisel
-            '';
-          };
-
         enclaver = pkgs.rustPlatform.buildRustPackage rec {
           pname = "enclaver";
-          version = "0.5.0";
+          version = "0.6.1";
 
           src = pkgs.fetchFromGitHub {
             owner = "enclaver-io";
             repo = pname;
             rev = "v${version}";
-            hash = "sha256-gfzfgcnVDRqywAJ/SC2Af6VfHPELDkoVlkhaKElMP2g=";
+            hash = "sha256-TdwfTJR2k3/y01l6fuke5MUxQLH8DU0nqfq3mGY1C9Y=";
           };
 
-          useFetchCargoVendor = true;
-          cargoHash = "sha256-o+CzTn5++Mj6SP9yFeTOBn4feapnL2m1EsYmXQBqTuc=";
+          cargoHash = "sha256-qhZBxj1lAY6vRe3/3mRHKhPk+mrUW/99ZPaVKOAnHj8=";
           cargoRoot = "enclaver";
           buildAndTestSubdir = cargoRoot;
         };
@@ -161,18 +124,19 @@
             ];
 
             packages = [
+              go_1_23_8
+              foundry_1_2_3
+              anvil_1_5_1
+
               enclaver
               eth-beacon-genesis
               eth2-val-tools
-              go_1_23_8
 
               pkgs.awscli2
               pkgs.cargo
               pkgs.dasel
-              foundry-bin-1_2_3
               pkgs.go-ethereum
               pkgs.jq
-              pkgs.just
               pkgs.just
               pkgs.pnpm
               pkgs.python311
@@ -184,7 +148,6 @@
             ];
 
             shellHook = ''
-              export FOUNDRY_DISABLE_NIGHTLY_WARNING=1
               export MACOSX_DEPLOYMENT_TARGET=14.5
               export PATH=$PATH:$PWD/op-deployer/bin
             '';

--- a/flake.nix
+++ b/flake.nix
@@ -134,7 +134,7 @@
 
               pkgs.awscli2
               pkgs.cargo
-              pkgs.dasel
+              (import inputs.pkgs-go { inherit system; }).dasel
               pkgs.go-ethereum
               pkgs.jq
               pkgs.just

--- a/justfile
+++ b/justfile
@@ -18,8 +18,8 @@ fast-tests:
 devnet-tests: build-devnet
   U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -v ./espresso/devnet-tests/...
 
-devnet-smoke-test-without-tee: build-devnet
-  U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -run 'TestSmokeWithoutTEE' -v ./espresso/devnet-tests/...
+devnet-smoke-test: build-devnet
+  U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -run 'TestSmoke' -v ./espresso/devnet-tests/...
 
 devnet-challenge-test: build-devnet
   U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -v -run TestChallengeGame ./espresso/devnet-tests/...
@@ -38,7 +38,7 @@ devnet-batcher-switching-test: build-devnet
 devnet-batcher-active-publish-only-test: build-devnet
   U_ID={{uid}} GID={{gid}} go test -timeout 30m -p 1 -count 1 -v -run TestBatcherActivePublishOnly ./espresso/devnet-tests/...
 
-build-devnet: stop-containers compile-contracts
+build-devnet: stop-containers
   rm -Rf espresso/deployment
   (cd op-deployer && just)
   (cd espresso && ./scripts/prepare-allocs.sh && docker compose build)

--- a/op-batcher/enclave-tools/cmd/main.go
+++ b/op-batcher/enclave-tools/cmd/main.go
@@ -328,6 +328,7 @@ func runAction(c *cli.Context) error {
 	slog.Info("Starting enclave", "image", imageName)
 	err = enclaverCli.RunEnclave(ctx, imageName, args)
 	if err != nil {
+		slog.Error("Failed to start enclave", "image", imageName, "error", err)
 		return err
 	}
 

--- a/op-batcher/enclave-tools/enclaver.go
+++ b/op-batcher/enclave-tools/enclaver.go
@@ -131,9 +131,6 @@ func (*EnclaverCli) BuildEnclave(ctx context.Context, manifest EnclaverManifest)
 }
 
 // RunEnclave runs an enclaver EIF image `name` with the provided arguments.
-// Uses 'docker run' directly (not 'enclaver run') to support --publish.
-// --publish=127.0.0.1:port:port instead of --net=host keeps the container off the host network
-// stack, blocking EC2 metadata-service access (requires IMDSv2 with HttpPutResponseHopLimit=1).
 func (*EnclaverCli) RunEnclave(ctx context.Context, name string, args []string) (retErr error) {
 	// We'll append this to container name to avoid conflicts
 	nameSuffix := uuid.New().String()[:8]
@@ -146,8 +143,7 @@ func (*EnclaverCli) RunEnclave(ctx context.Context, name string, args []string) 
 		"--rm",
 		"-d",
 		"--privileged",
-		fmt.Sprintf("--publish=127.0.0.1:%d:%d", ArgDeliveryPort, ArgDeliveryPort),
-		fmt.Sprintf("--publish=127.0.0.1:%d:%d", ReadinessPort, ReadinessPort),
+		"--net=host",
 		"--name="+containerName,
 		"--device=/dev/nitro_enclaves",
 		name,

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -11,8 +11,6 @@ build_info_path = 'artifacts/build-info'
 snapshots = 'notarealpath'               # workaround for foundry#9477
 allow_internal_expect_revert = true      # workaround described in https://github.com/PaulRBerg/prb-math/issues/248
 
-use_literal_content = true
-
 optimizer = true
 optimizer_runs = 999999
 
@@ -178,3 +176,10 @@ src = 'test/kontrol/proofs'
 out = 'kout-proofs'
 test = 'test/kontrol/proofs'
 script = 'test/kontrol/proofs'
+
+################################################################
+#                         PROFILE: VERIFICATION                #
+################################################################
+
+[profile.verification]
+use_literal_content = true


### PR DESCRIPTION
### This PR:
- Fixes the batcher restart test in TEE environment
- Adds CI workflows to run ALL devnet tests with the TEE compose profile on Nitro-enabled EC2 instances:
  - `ec2-devnet-test.yaml` — reusable workflow managing EC2 runner lifecycle (start → test → stop)
  - `espresso-devnet-tests-tee.yaml` — mirrors non-TEE devnet tests with 4 parallel groups on EC2


### This PR does not:
- Enable withdrawal and challenge tests in TEE environment - succinct-proposer is not set up in `tee` devnet profile

### How to test this PR:
* There are indeed TEE devnet tests in CI and they pass