### PR TITLE
Fix derivation test build and UnmarshalEspressoTransaction Panics

### DIFF
--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -381,7 +381,7 @@ func TestBlobDataSourceL1FetcherErrors(t *testing.T) {
 	blob := new(eth.Blob)
 	err = blob.FromData(blobInput)
 	require.NoError(t, err)
-	_, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{blob})
+	_, blobHashes, err := txmgr.MakeSidecar([]*eth.Blob{blob}, false)
 	require.NoError(t, err)
 	blobTxData := &types.BlobTx{
 		Nonce:      rng.Uint64(),

--- a/op-node/rollup/derive/espresso_batch.go
+++ b/op-node/rollup/derive/espresso_batch.go
@@ -97,6 +97,9 @@ func CreateEspressoBatchUnmarshaler() func(data []byte) (*EspressoBatch, error) 
 }
 
 func UnmarshalEspressoTransaction(data []byte) (*EspressoBatch, error) {
+	if len(data) < crypto.SignatureLength {
+		return nil, fmt.Errorf("transaction data too short: %d bytes, need at least %d", len(data), crypto.SignatureLength)
+	}
 	signatureData, batchData := data[:crypto.SignatureLength], data[crypto.SignatureLength:]
 	batchHash := crypto.Keccak256(batchData)
 

--- a/op-node/rollup/derive/espresso_batch_test.go
+++ b/op-node/rollup/derive/espresso_batch_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var defaultTestRollUpConfig = &rollup.Config{
@@ -79,6 +80,22 @@ func compareBody(a, b *gethTypes.Body) int {
 	}
 
 	return 0
+}
+
+// TestUnmarshalEspressoTransactionTooShort verifies that UnmarshalEspressoTransaction
+// returns an error (rather than panicking) when the input is shorter than a signature.
+func TestUnmarshalEspressoTransactionTooShort(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{},
+		make([]byte, crypto.SignatureLength-1),
+	}
+	for _, data := range cases {
+		_, err := derive.UnmarshalEspressoTransaction(data)
+		if err == nil {
+			t.Errorf("expected error for %d-byte input, got nil", len(data))
+		}
+	}
 }
 
 // TestEspressoBatchConversion tests the conversion of a block to an Espresso

--- a/op-node/rollup/derive/espresso_batch_test.go
+++ b/op-node/rollup/derive/espresso_batch_test.go
@@ -92,8 +92,7 @@ func TestUnmarshalEspressoTransactionTooShort(t *testing.T) {
 	}
 	for _, data := range cases {
 		_, err := derive.UnmarshalEspressoTransaction(data)
-		if err == nil {
-			t.Errorf("expected error for %d-byte input, got nil", len(data))
+		require.Error(t, err, "expected error for %d-byte input", len(data))
 		}
 	}
 }

--- a/op-node/rollup/derive/espresso_batch_test.go
+++ b/op-node/rollup/derive/espresso_batch_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
 )
 
 var defaultTestRollUpConfig = &rollup.Config{
@@ -93,7 +94,6 @@ func TestUnmarshalEspressoTransactionTooShort(t *testing.T) {
 	for _, data := range cases {
 		_, err := derive.UnmarshalEspressoTransaction(data)
 		require.Error(t, err, "expected error for %d-byte input", len(data))
-		}
 	}
 }
 


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213948846870077?focus=true.
Closes https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1213749992420791?focus=true.

### This PR:
* Fixes the build for `op-node/rollup/derive`.
* Adds a length check for the signature to avoid panics on the transaction unmarshalling.
* Adds a unit test for this fix.

### How to test this PR:
* Run `go test -run '^TestUnmarshalEspressoTransactionTooShort$' ./op-node/rollup/derive/` and verify the test passes.