### PR TITLE
Add KMS signer support to run-enclave.sh

### DIFF
--- a/espresso/docker/op-batcher-tee/run-enclave.sh
+++ b/espresso/docker/op-batcher-tee/run-enclave.sh
@@ -75,6 +75,8 @@ echo "Debug Mode: $ENCLAVE_DEBUG"
 echo "Monitor Interval: $MONITOR_INTERVAL seconds"
 echo "Memory: ${MEMORY_MB}MB"
 echo "CPU Count: $CPU_COUNT"
+echo "KMS Signer Endpoint: ${SIGNER_ENDPOINT:-[not set]}"
+echo "KMS Signer Address: ${SIGNER_ADDRESS:-[not set]}"
 echo "Max Channel Duration: $MAX_CHANNEL_DURATION"
 echo "Target Num Frames: $TARGET_NUM_FRAMES"
 echo "Max L1 Tx Size Bytes: $MAX_L1_TX_SIZE_BYTES"
@@ -93,8 +95,17 @@ BATCHER_ARGS="$BATCHER_ARGS,--espresso.batch-authenticator-addr=$BATCH_AUTHENTIC
 BATCHER_ARGS="$BATCHER_ARGS,--espresso.origin-height-espresso=$ESPRESSO_ORIGIN_HEIGHT_ESPRESSO"
 BATCHER_ARGS="$BATCHER_ARGS,--espresso.origin-height-l2=$ESPRESSO_ORIGIN_HEIGHT_L2"
 
-# Use private key if provided, otherwise fall back to test mnemonic
-if [ -n "$OP_BATCHER_PRIVATE_KEY" ]; then
+# Use KMS signer if endpoint+address are provided, otherwise fall back to private key or test mnemonic.
+if [ -n "${SIGNER_ENDPOINT:-}" ] || [ -n "${SIGNER_ADDRESS:-}" ]; then
+    if [ -n "${SIGNER_ENDPOINT:-}" ] && [ -n "${SIGNER_ADDRESS:-}" ]; then
+        echo "Using KMS signer at $SIGNER_ENDPOINT (address: $SIGNER_ADDRESS)"
+        BATCHER_ARGS="$BATCHER_ARGS,--signer.endpoint=$SIGNER_ENDPOINT"
+        BATCHER_ARGS="$BATCHER_ARGS,--signer.address=$SIGNER_ADDRESS"
+    else
+        echo "ERROR: Both SIGNER_ENDPOINT and SIGNER_ADDRESS must be set to use KMS signer"
+        exit 1
+    fi
+elif [ -n "$OP_BATCHER_PRIVATE_KEY" ]; then
     echo "Using OP_BATCHER_PRIVATE_KEY for authentication"
     BATCHER_ARGS="$BATCHER_ARGS,--private-key=$OP_BATCHER_PRIVATE_KEY"
 else
@@ -123,6 +134,10 @@ BATCHER_ARGS="$BATCHER_ARGS,--data-availability-type=calldata"
 if [ "$ENCLAVE_DEBUG" = "true" ]; then
     BATCHER_ARGS="$BATCHER_ARGS,--log.level=debug"
     echo "Debug logging enabled"
+fi
+
+if [ -n "${SIGNER_TLS_ENABLED:-}" ]; then
+    BATCHER_ARGS="$BATCHER_ARGS,--signer.tls.enabled=$SIGNER_TLS_ENABLED"
 fi
 
 # Remove any stale enclave containers from previous runs.
@@ -233,6 +248,19 @@ echo "Starting enclave with image: $TAG (args contain sensitive data and are not
 
 enclave-tools run --image "$TAG" --args "$BATCHER_ARGS" &
 ENCLAVE_TOOLS_PID=$!
+
+# Start log capture early so we see crash output before --rm wipes the container.
+for _ in $(seq 1 20); do
+    EARLY_CID=$(docker ps -aq --filter "name=batcher-enclaver-" | head -1)
+    [ -n "$EARLY_CID" ] && break
+    sleep 0.5
+done
+if [ -n "$EARLY_CID" ]; then
+    echo "Early log capture attached to container $EARLY_CID"
+    docker logs -f "$EARLY_CID" 2>&1 | sed 's/^/[ENCLAVE-EARLY] /' | tee /tmp/enclave-early.log &
+else
+    echo "WARNING: enclave container did not appear within 10s for early log capture"
+fi
 
 if [ "$DEPLOYMENT_MODE" = "local" ]; then
     echo "$ENCLAVE_TOOLS_PID" > "$PID_FILE"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4424,6 +4424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12973,13 +12979,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "munge",
  "ptr_meta",
@@ -12992,9 +12998,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## This PR

- Add KMS signer path to `run-enclave.sh`: when `SIGNER_ENDPOINT` and `SIGNER_ADDRESS` env vars are set, pass `--signer.endpoint` and `--signer.address` to the enclave batcher instead of `--private-key`.
- Fully backward-compatible: if neither env var is set, existing `OP_BATCHER_PRIVATE_KEY` or test mnemonic paths are unchanged.
- Log the signer endpoint and address in the startup config summary.

## Key Places to Review

- `espresso/docker/op-batcher-tee/run-enclave.sh` — authentication section (lines ~96-107): KMS signer branch added above the existing private key branch.

## How to Test This PR

1. Deploy with `enable_kms_signer = true` in `tee-op-deploy` — the ECS task will set `SIGNER_ENDPOINT` and `SIGNER_ADDRESS` env vars on the container.
2. Confirm the enclave batcher starts with `--signer.endpoint` and `--signer.address` in its args (visible in logs).
3. Confirm existing deployments with `enable_kms_signer = false` are unaffected — the private key path runs as before.